### PR TITLE
Database Refreshing and Well Starting First

### DIFF
--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -33,12 +33,19 @@ var _outerFunc = module.exports = {
 			if (!stats) {
 				_outerFunc.CreateNewEmptyFile(_dbPathWithName);
 				_outerFunc.CreateNewEmptyFile(_csvPathWithName);
-
 				_outerFunc.CreateNewDatabase(_mapping);
 
-				CreateNewCsv();
+				var tempHeaders = [];
+				var csvData = [];
+				Object.keys(_data).forEach((key) => {
+					tempHeaders.push(key);
+					// --Pushing an empty character because something has to be written on creation
+					csvData.push('');
+				});
+				_outerFunc.WriteToCsv(csvData, _csvPathWithName, { headers: tempHeaders });
+
 				_outerFunc.WriteToDatabase();
-				_outerFunc.WriteToCsv();
+				_outerFunc.AddToCsv();
 			}
 
 			_data = _outerFunc.ReadDatabase();
@@ -54,17 +61,6 @@ var _outerFunc = module.exports = {
 
 			callback(recentData);
 		});
-
-		function CreateNewCsv() {
-			var tempHeaders = [];
-			var csvData = [];
-			Object.keys(_data).forEach((key) => {
-				tempHeaders.push(key);
-				// --Pushing an empty character because something has to be written on creation
-				csvData.push('');
-			});
-			_outerFunc.CsvWriter(csvData, _csvPathWithName, { headers: tempHeaders });
-		}
 	},
 	
 	GetRecentlyLoggedData: function() {
@@ -75,7 +71,7 @@ var _outerFunc = module.exports = {
 		return recentData;
 	},
 
-	WriteToCsv: function() {
+	AddToCsv: function() {
 		var csvData = _outerFunc.GetRecentlyLoggedData();
 		var keys = Object.keys(csvData);
 
@@ -92,7 +88,7 @@ var _outerFunc = module.exports = {
 			i++;
 		}
 
-		_outerFunc.CsvWriter(csvData, _csvPathWithName, { sendHeaders: false }, { flags: 'a' });
+		_outerFunc.WriteToCsv(csvData, _csvPathWithName, { sendHeaders: false }, { flags: 'a' });
 	},
 
 	WriteToDatabase: function() {
@@ -114,7 +110,7 @@ var _outerFunc = module.exports = {
 		return JSON.parse(_fs.readFileSync(_dbPathWithName));
 	},
 	
-	CsvWriter: function(csvData, filePath, csvWriterArgs, writeStreamArgs) {
+	WriteToCsv: function(csvData, filePath, csvWriterArgs, writeStreamArgs) {
 		var writer = _csvWriter(csvWriterArgs);
 		writer.pipe(_fs.createWriteStream(filePath, writeStreamArgs));
 		writer.write(csvData);

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -129,7 +129,7 @@ var _outerFunc = module.exports = {
 		_fs.renameSync(_csvPathWithName, FormatArchivePath(_csvFileName, CSV_FILE_EXTENSION));
 
 		_outerFunc.LoadDatabase(_mapping, () => {
-			module.exports.AddToDatabase(dataToKeep);
+			_outerFunc.AddToDatabase(dataToKeep);
 		});
 		
 		_fs.unlinkSync(dbArchivePathWithName);
@@ -143,7 +143,7 @@ var _outerFunc = module.exports = {
 	RefreshDatabase: function() {
 		var dataToKeep = _outerFunc.GetRecentlyLoggedData();
 		_fs.unlinkSync(_dbPathWithName);
-		
+
 		_outerFunc.CreateNewEmptyFile(_dbPathWithName);
 		_outerFunc.CreateNewDatabase(_mapping);
 		_outerFunc.AddToDatabase(dataToKeep);

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -135,7 +135,6 @@ var _outerFunc = module.exports = {
 
 		_outerFunc.LoadDatabase(_mapping, () => {
 			module.exports.AddToDatabase(dataToKeep);
-			module.exports.WriteToCsv();
 		});
 		
 		_fs.unlinkSync(dbArchivePathWithName);

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -34,13 +34,10 @@ var _outerFunc = module.exports = {
 		_fs.stat(_dbPathWithName, (err, stats) => {
 			// --Stats will be false if the db file is not found, and a new db and csv will be created
 			if (!stats) {
-				_fs.openSync(_dbPathWithName, 'w');
-				_fs.openSync(_csvPathWithName, 'w');
+				_fs.closeSync(_fs.openSync(_dbPathWithName, 'w'));
+				_fs.closeSync(_fs.openSync(_csvPathWithName, 'w'));
 
-				_data = {};
-				Object.keys(mapping).forEach((key) => {
-					_data[mapping[key]] = [];
-				});
+				_outerFunc.CreateNewDatabase(_mapping);
 
 				CreateNewCsv();
 				_outerFunc.WriteToDatabase();
@@ -144,4 +141,19 @@ var _outerFunc = module.exports = {
 			return ARCHIVE_PATH + fileName + '-' + date + fileExtension;
 		}
 	},
+
+	RefreshDatabase: function() {
+		var dataToKeep = _outerFunc.GetRecentlyLoggedData();
+		_fs.unlinkSync(_dbPathWithName);
+		_fs.closeSync(_fs.openSync(_dbPathWithName, 'w'));
+		_outerFunc.CreateNewDatabase(_mapping);
+		_outerFunc.AddToDatabase(dataToKeep);
+	},
+
+	CreateNewDatabase: function(mapping) {
+		_data = {};
+		Object.keys(mapping).forEach((key) => {
+			_data[mapping[key]] = [];
+		});
+	}
 }

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -34,8 +34,8 @@ var _outerFunc = module.exports = {
 		_fs.stat(_dbPathWithName, (err, stats) => {
 			// --Stats will be false if the db file is not found, and a new db and csv will be created
 			if (!stats) {
-				_fs.closeSync(_fs.openSync(_dbPathWithName, 'w'));
-				_fs.closeSync(_fs.openSync(_csvPathWithName, 'w'));
+				_outerFunc.CreateNewEmptyFile(_dbPathWithName);
+				_outerFunc.CreateNewEmptyFile(_csvPathWithName);
 
 				_outerFunc.CreateNewDatabase(_mapping);
 
@@ -43,6 +43,7 @@ var _outerFunc = module.exports = {
 				_outerFunc.WriteToDatabase();
 				_outerFunc.WriteToCsv();
 			}
+
 			_data = _outerFunc.ReadDatabase();
 			_headers = Object.keys(_data);
 
@@ -145,7 +146,7 @@ var _outerFunc = module.exports = {
 	RefreshDatabase: function() {
 		var dataToKeep = _outerFunc.GetRecentlyLoggedData();
 		_fs.unlinkSync(_dbPathWithName);
-		_fs.closeSync(_fs.openSync(_dbPathWithName, 'w'));
+		_outerFunc.CreateNewEmptyFile(_dbPathWithName);
 		_outerFunc.CreateNewDatabase(_mapping);
 		_outerFunc.AddToDatabase(dataToKeep);
 	},
@@ -155,5 +156,9 @@ var _outerFunc = module.exports = {
 		Object.keys(mapping).forEach((key) => {
 			_data[mapping[key]] = [];
 		});
+	},
+
+	CreateNewEmptyFile: function(filePath) {
+		_fs.closeSync(_fs.openSync(filePath, 'w'));
 	}
 }

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -143,6 +143,7 @@ var _outerFunc = module.exports = {
 	RefreshDatabase: function() {
 		var dataToKeep = _outerFunc.GetRecentlyLoggedData();
 		_fs.unlinkSync(_dbPathWithName);
+		
 		_outerFunc.CreateNewEmptyFile(_dbPathWithName);
 		_outerFunc.CreateNewDatabase(_mapping);
 		_outerFunc.AddToDatabase(dataToKeep);

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -17,9 +17,6 @@ var _data;
 var _headers;
 var _mapping;
 
-// --Database == .json file
-// --CSV == .csv file
-
 var _outerFunc = module.exports = {
 	LoadDatabase: function(mapping, callback, isTest) {
 		_mapping = mapping;
@@ -51,7 +48,7 @@ var _outerFunc = module.exports = {
 
 			Object.keys(recentData).forEach((key) => {
 				// --Will be undefined if from a new CSV and 0 is more friendly
-				if (recentData[key] == undefined)
+				if (recentData[key] === undefined)
 					recentData[key] = 0;
 			});
 
@@ -85,12 +82,12 @@ var _outerFunc = module.exports = {
 		// --Only format the sections that require it.
 		var i = 0;
 		while (i < keys.length) {
-			if (keys[i] == _mapping.DATE || keys[i] == _mapping.WELL_RECHARGE_COUNTER || keys[i] == _mapping.CFH_COUNTER) {
+			if (keys[i] === _mapping.DATE || keys[i] === _mapping.WELL_RECHARGE_COUNTER || keys[i] === _mapping.CFH_COUNTER) {
 				i++;
 				continue;
 			}
 			var num = csvData[keys[i]];
-			if (num != undefined)
+			if (num !== undefined)
 				csvData[keys[i]] = _dto.MinutesAsHoursMins(num);
 			i++;
 		}

--- a/bin/database-tests.js
+++ b/bin/database-tests.js
@@ -19,12 +19,13 @@ _dbo.LoadDatabase(_mapping, (recentData) => {
 	_newData = recentData;
 	
 	Fill(() => {
-		console.log('Files created with dummy data.\nEnter \"a\" to run a test archive.\nPress \"enter\" to exit.');
+		console.log('Files created with dummy data.\nEnter \"a\" to run a test archive.\nEnter \"r\" to refresh the database.\nPress \"enter\" to exit.');
 		_rl.on('line', (input) => {
 			if (input == 'a') {
 				_dbo.CreateArchives();
 				console.log('Archive completed, exiting...');
-			}
+			} else if (input === 'r')
+				_dbo.RefreshDatabase();
 			else
 				console.log('Exiting.');
 			_rl.close();

--- a/bin/database-tests.js
+++ b/bin/database-tests.js
@@ -1,47 +1,49 @@
 
-var _dbo = require('./database-operations');
-var	_schedule = require('node-schedule');
-var	_rl = require('readline').createInterface({ input: process.stdin, output: process.stdout });
-var	_dto = require('./date-time-operations');
+(function() {
+	var _dbo = require('./database-operations');
+	var	_schedule = require('node-schedule');
+	var	_rl = require('readline').createInterface({ input: process.stdin, output: process.stdout });
+	var	_dto = require('./date-time-operations');
 
-var _mapping = require('./mapping').GetMapping();
-var _newData;
+	var _mapping = require('./mapping').GetMapping();
+	var _newData;
 
-_dbo.LoadDatabase(_mapping, (recentData) => {
-	_newData = recentData;
-	
-	Fill(() => {
-		console.log('Files created with dummy data.\nEnter \"a\" to run a test archive.\nEnter \"r\" to refresh the database.\nPress \"enter\" to exit.');
-		_rl.on('line', (input) => {
-			if (input == 'a') {
-				_dbo.CreateArchives();
-				console.log('Archive completed, exiting...');
-			} else if (input === 'r')
-				_dbo.RefreshDatabase();
-			else
-				console.log('Exiting.');
-			_rl.close();
+	_dbo.LoadDatabase(_mapping, (recentData) => {
+		_newData = recentData;
+		
+		Fill(() => {
+			console.log('Files created with dummy data.\nEnter \"a\" to run a test archive.\nEnter \"r\" to refresh the database.\nPress \"enter\" to exit.');
+			_rl.on('line', (input) => {
+				if (input == 'a') {
+					_dbo.CreateArchives();
+					console.log('Archive completed, exiting...');
+				} else if (input === 'r')
+					_dbo.RefreshDatabase();
+				else
+					console.log('Exiting.');
+				_rl.close();
+			});
 		});
-	});
-}, true);
+	}, true);
 
-function Fill(callback) {
-	var i = 0;
-	var max = 90;
-	_newData[_mapping.WELL_TIMER] = max;
-	var interval = setInterval(() => {
-		if (i != max) {
-			++_newData[_mapping.WELL_RECHARGE_COUNTER];
-			++_newData[_mapping.COLUMBIA_TIMER];
-			--_newData[_mapping.WELL_TIMER];
-			_newData[_mapping.CFH_COUNTER] = Math.floor(Math.random() * (max - 1) + i);
-			_newData[_mapping.WELL_RECHARGE_TIMER] = --_newData[_mapping.CFH_COUNTER];
-			_dbo.AddToDatabase(_newData);
-			_dbo.WriteToCsv();
-			i++;
-		} else {
-			clearInterval(interval);
-			callback();
-		}
-	}, 10);
-}
+	function Fill(callback) {
+		var i = 0;
+		var max = 90;
+		_newData[_mapping.WELL_TIMER] = max;
+		var interval = setInterval(() => {
+			if (i != max) {
+				++_newData[_mapping.WELL_RECHARGE_COUNTER];
+				++_newData[_mapping.COLUMBIA_TIMER];
+				--_newData[_mapping.WELL_TIMER];
+				_newData[_mapping.CFH_COUNTER] = Math.floor(Math.random() * (max - 1) + i);
+				_newData[_mapping.WELL_RECHARGE_TIMER] = --_newData[_mapping.CFH_COUNTER];
+				_dbo.AddToDatabase(_newData);
+				_dbo.WriteToCsv();
+				i++;
+			} else {
+				clearInterval(interval);
+				callback();
+			}
+		}, 10);
+	}
+})();

--- a/bin/database-tests.js
+++ b/bin/database-tests.js
@@ -40,7 +40,7 @@
 				_newData[_mapping.CFH_COUNTER] = Math.floor(Math.random() * (max - 1) + i);
 				_newData[_mapping.WELL_RECHARGE_TIMER] = --_newData[_mapping.CFH_COUNTER];
 				_dbo.AddToDatabase(_newData);
-				_dbo.WriteToCsv();
+				_dbo.AddToCsv();
 				i++;
 			} else {
 				clearInterval(interval);

--- a/bin/database-tests.js
+++ b/bin/database-tests.js
@@ -4,15 +4,7 @@ var	_schedule = require('node-schedule');
 var	_rl = require('readline').createInterface({ input: process.stdin, output: process.stdout });
 var	_dto = require('./date-time-operations');
 
-var _mapping = {
-	DATE: 'Date',
-	WELL_TIMER: 'Well Timer',
-	COLUMBIA_TIMER: 'Columbia Timer',
-	WELL_RECHARGE_COUNTER: 'Well Counter',
-	CFH_COUNTER : 'Call For Heat Counter',
-	WELL_RECHARGE_TIMER: 'Well Recharge Timer'
-}
-
+var _mapping = require('./mapping').GetMapping();
 var _newData;
 
 _dbo.LoadDatabase(_mapping, (recentData) => {

--- a/bin/database-tests.js
+++ b/bin/database-tests.js
@@ -17,8 +17,10 @@
 				if (input == 'a') {
 					_dbo.CreateArchives();
 					console.log('Archive completed, exiting...');
-				} else if (input === 'r')
+				} else if (input === 'r') {
 					_dbo.RefreshDatabase();
+					console.log('Refresh completed, exiting...');
+				}
 				else
 					console.log('Exiting.');
 				_rl.close();

--- a/bin/mapping.js
+++ b/bin/mapping.js
@@ -2,9 +2,8 @@
 
 var _outerFunc = module.exports = {
 	GetMapping: function() {
-		// --Note: if the keys are renamed, go to database-operations.js and make sure that the names
-		// in WriteToCsv() are changed to match
-		var mapping = {
+		// --Note: if the keys are renamed, other files that use this will have to be changed accordingly.
+		return {
 			DATE: 'Date',
 			WELL_TIMER: 'Well Timer',
 			COLUMBIA_TIMER: 'Columbia Timer',
@@ -12,7 +11,5 @@ var _outerFunc = module.exports = {
 			CFH_COUNTER : 'Call For Heat Counter',
 			WELL_RECHARGE_TIMER: 'Well Recharge Timer'
 		}
-
-		return mapping;
 	}
 }

--- a/bin/mapping.js
+++ b/bin/mapping.js
@@ -1,0 +1,18 @@
+
+
+var _outerFunc = module.exports = {
+	GetMapping: function() {
+		// --Note: if the keys are renamed, go to database-operations.js and make sure that the names
+		// in WriteToCsv() are changed to match
+		var mapping = {
+			DATE: 'Date',
+			WELL_TIMER: 'Well Timer',
+			COLUMBIA_TIMER: 'Columbia Timer',
+			WELL_RECHARGE_COUNTER: 'Well Counter',
+			CFH_COUNTER : 'Call For Heat Counter',
+			WELL_RECHARGE_TIMER: 'Well Recharge Timer'
+		}
+
+		return mapping;
+	}
+}

--- a/bin/program.js
+++ b/bin/program.js
@@ -11,8 +11,9 @@
 	const RECHARGE_TIME_MINUTES = 90;
 	const ALL_TIMERS_INTERVAL_MILLI = 60000;
 	const INPUT_CHECK_INTERVAL_MILLI = 50;
-	const CRON_CSV_WRITE_SCHEDULE = '0 7,19 * * *';
-	const CRON_ARCHIVE_SCHEDULE = '0 0 1 */1 *';
+	const CRON_CSV_WRITE_SCHEDULE = '0 7,19 * * *'; // --Every day at 7 am/pm
+	const CRON_ARCHIVE_SCHEDULE = '0 0 1 */1 *'; // --Every month at 12:00 am on the 1st
+	const CRON_DB_REFRESH_SCHEDULE = '0 0 */1 * *'; // --Every day at 12:00 am
 
 	var	_manualOverrideButton = new _blynk.VirtualPin(0); 
 	var	_manualColumbiaButton = new _blynk.VirtualPin(1); 
@@ -268,6 +269,9 @@
 		});
 		_schedule.scheduleJob(CRON_ARCHIVE_SCHEDULE, () => {
 			_dbo.CreateArchives();
+		});
+		_schedule.scheduleJob(CRON_DB_REFRESH_SCHEDULE, () => {
+			_dbo.RefreshDatabase();
 		});
 	}
 

--- a/bin/program.js
+++ b/bin/program.js
@@ -35,17 +35,8 @@
 	var	_wellValveRelayOutput = new _gpio(17, 'high');
 	var	_boilerStartRelayOutput = new _gpio(27, 'high');
 
-	// --Note: if the keys _mapping are renamed, go to database-operations and make sure that the names
-	// in WriteToCsv() are changed to match
-	var _mapping = {
-		DATE: 'Date',
-		WELL_TIMER: 'Well Timer',
-		COLUMBIA_TIMER: 'Columbia Timer',
-		WELL_RECHARGE_COUNTER: 'Well Counter',
-		CFH_COUNTER : 'Call For Heat Counter',
-		WELL_RECHARGE_TIMER: 'Well Recharge Timer'
-	}
-
+	
+	var _mapping = require('./mapping').GetMapping();
 	var _newData;
 	var _isWellCharged;
 	var _manualOverrideEnable = false;

--- a/bin/program.js
+++ b/bin/program.js
@@ -271,6 +271,10 @@
 		_columbiaTimerDisplay.write(_dto.MinutesAsHoursMins(_newData[_mapping.COLUMBIA_TIMER]));
 		_wellTimerDisplay.write(_dto.MinutesAsHoursMins(_newData[_mapping.WELL_TIMER]));
 		_ecobeeCfhCounterDisplay.write(_newData[_mapping.CFH_COUNTER]);
+
+		if (_newData[_mapping.WELL_RECHARGE_TIMER] === 0)
+			_newData[_mapping.WELL_RECHARGE_TIMER] = RECHARGE_TIME_MINUTES;
+
 		_wellRechargeTimerDisplay.write(_newData[_mapping.WELL_RECHARGE_TIMER]);
 	}
 })();

--- a/bin/program.js
+++ b/bin/program.js
@@ -256,7 +256,7 @@
 
 	function StartSchedules() {
 		_schedule.scheduleJob(CRON_CSV_WRITE_SCHEDULE, () => {
-	    	_dbo.WriteToCsv();
+	    	_dbo.AddToCsv();
 		});
 		_schedule.scheduleJob(CRON_ARCHIVE_SCHEDULE, () => {
 			_dbo.CreateArchives();


### PR DESCRIPTION
The database file can get kind of big (and nasty to look at), so now there is a schedule for "refreshing" the database every day, without touching the CSV. This "refresh" process will basically take the most recent data from the current db, delete the db, create a new db, and insert the saved data. This keeps the db small in size.

In addition:
- The `mapping` object has moved into its own file, because both `program.js` and `database-tests` use it.
- The CSV that is created after an archive will be blank (before it contained the most recent data from the last archive) as to not duplicate data