### PR TITLE
File Safety

### DIFF
--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -34,6 +34,7 @@ var _outerFunc = module.exports = {
 				_outerFunc.CreateNewEmptyFile(_dbPathWithName);
 
 				_fs.stat(_csvPathWithName, (err, stats) => {
+					// --Only create a new csv if that is not found either
 					if (!stats) {
 						_outerFunc.CreateNewEmptyFile(_csvPathWithName);
 						var tempHeaders = [];

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -29,12 +29,11 @@ var _outerFunc = module.exports = {
 		_csvPathWithName = DATA_PATH + _csvFileName + CSV_FILE_EXTENSION;
 
 		_fs.stat(_dbPathWithName, (err, stats) => {
-			// --Stats will be false if the db file is not found, and a new db will be created
-			if (!stats) {
+			// --Stats will be false if no file found, stats.size will be 0 if there is an empty file
+			if (!stats || stats.size === 0) {
 				_outerFunc.CreateNewEmptyFile(_dbPathWithName);
 
 				_fs.stat(_csvPathWithName, (err, stats) => {
-					// --Same as above but with the csv
 					if (!stats) {
 						_outerFunc.CreateNewEmptyFile(_csvPathWithName);
 						var tempHeaders = [];

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -59,7 +59,7 @@ var _outerFunc = module.exports = {
 			var recentData = _outerFunc.GetRecentlyLoggedData();
 
 			Object.keys(recentData).forEach((key) => {
-				// --Will be undefined if from a new CSV and 0 is more friendly
+				// --Will be undefined if a new db was just created
 				if (recentData[key] === undefined)
 					recentData[key] = 0;
 			});
@@ -158,6 +158,7 @@ var _outerFunc = module.exports = {
 	},
 
 	CreateNewEmptyFile: function(filePath) {
+		// --Creates a new file and then closes it so it can be accessed right away
 		_fs.closeSync(_fs.openSync(filePath, 'w'));
 	}
 }

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -32,6 +32,8 @@ var _outerFunc = module.exports = {
 			// --Stats will be false if no file found, stats.size will be 0 if there is an empty file
 			if (!stats || stats.size === 0) {
 				_outerFunc.CreateNewEmptyFile(_dbPathWithName);
+				_outerFunc.CreateNewDatabase(_mapping);
+				_outerFunc.WriteToDatabase();
 
 				_fs.stat(_csvPathWithName, (err, stats) => {
 					// --Only create a new csv if that is not found either
@@ -45,12 +47,9 @@ var _outerFunc = module.exports = {
 							csvData.push('');
 						});
 						_outerFunc.WriteToCsv(csvData, _csvPathWithName, { headers: tempHeaders });
+						_outerFunc.AddToCsv();
 					}
 				});
-				
-				_outerFunc.CreateNewDatabase(_mapping);
-				_outerFunc.WriteToDatabase();
-				_outerFunc.AddToCsv();
 			}
 
 			_data = _outerFunc.ReadDatabase();

--- a/bin/database-operations.js
+++ b/bin/database-operations.js
@@ -29,21 +29,26 @@ var _outerFunc = module.exports = {
 		_csvPathWithName = DATA_PATH + _csvFileName + CSV_FILE_EXTENSION;
 
 		_fs.stat(_dbPathWithName, (err, stats) => {
-			// --Stats will be false if the db file is not found, and a new db and csv will be created
+			// --Stats will be false if the db file is not found, and a new db will be created
 			if (!stats) {
 				_outerFunc.CreateNewEmptyFile(_dbPathWithName);
-				_outerFunc.CreateNewEmptyFile(_csvPathWithName);
-				_outerFunc.CreateNewDatabase(_mapping);
 
-				var tempHeaders = [];
-				var csvData = [];
-				Object.keys(_data).forEach((key) => {
-					tempHeaders.push(key);
-					// --Pushing an empty character because something has to be written on creation
-					csvData.push('');
+				_fs.stat(_csvPathWithName, (err, stats) => {
+					// --Same as above but with the csv
+					if (!stats) {
+						_outerFunc.CreateNewEmptyFile(_csvPathWithName);
+						var tempHeaders = [];
+						var csvData = [];
+						Object.keys(_data).forEach((key) => {
+							tempHeaders.push(key);
+							// --Pushing an empty character because something has to be written on creation
+							csvData.push('');
+						});
+						_outerFunc.WriteToCsv(csvData, _csvPathWithName, { headers: tempHeaders });
+					}
 				});
-				_outerFunc.WriteToCsv(csvData, _csvPathWithName, { headers: tempHeaders });
-
+				
+				_outerFunc.CreateNewDatabase(_mapping);
 				_outerFunc.WriteToDatabase();
 				_outerFunc.AddToCsv();
 			}

--- a/bin/program.js
+++ b/bin/program.js
@@ -265,20 +265,20 @@
 	}
 
 	function StartSchedules() {
+		/*
+			File operations while there's a chance of reading/writing to them can be dangerous. 
+			If there is a call for heat or the well is not charged the system is most likely reading/writing data, and
+				if this happens when one of the schedules are to run there is a chance that something will break, which is 
+				not good. 
+			This method will contrinue to try and run the schedule every minute after the initial run.
+			It will rest to default on success.
+		*/
 
 		CreateSchedule(CRON_CSV_WRITE_SCHEDULE, _dbo.AddToCsv);
 		CreateSchedule(CRON_ARCHIVE_SCHEDULE, _dbo.CreateArchives);
 		CreateSchedule(CRON_DB_REFRESH_SCHEDULE, _dbo.RefreshDatabase);
 
 		function CreateSchedule(originalSchedule, executeFunction) {
-			/*
-				File operations while there's a chance of reading/writing to them can be dangerous. 
-				If there is a call for heat or the well is not charged the system is most likely reading/writing data, and
-					if this happens when one of the schedules are to run there is a chance that something will break, which is 
-					not good. 
-				This method will contrinue to try and run the schedule every minute after the initial run.
-				It will rest to default on success.
-			*/
 			var newSchedule = originalSchedule;
 			var job = _schedule.scheduleJob(originalSchedule, () => {
 				job.cancel();

--- a/bin/program.js
+++ b/bin/program.js
@@ -58,7 +58,7 @@
 	// --End main function
 
 	function MonitorEcobeeCallForHeat() {
-		var countLogged = true;
+		var countLogged = false;
 		StartTimer(() => {
 			if (_ecobeeCfhInput.readSync() === 1 && !_manualOverrideEnable) {
 				if (!countLogged) {

--- a/bin/program.js
+++ b/bin/program.js
@@ -271,7 +271,13 @@
 		CreateSchedule(CRON_DB_REFRESH_SCHEDULE, _dbo.RefreshDatabase);
 
 		function CreateSchedule(originalSchedule, executeFunction) {
-			// --This will add one minute to the schedule and try again if need b. It will rest to default on success.
+			/*
+				File operations while there's a chance of reading/writing to them can be dangerous. 
+				If there is a call for heat or the well is not charged the system is most likely reading/writing data, and
+					if this happens when one of the schedules are to run there is a chance that something will break, which is 
+					super not good. This will contrinue to try and run the schedule a minute later and will continue to do so.
+				It will rest to default on success.
+			*/
 			var newSchedule = originalSchedule;
 			var job = _schedule.scheduleJob(originalSchedule, () => {
 				job.cancel();

--- a/bin/program.js
+++ b/bin/program.js
@@ -258,23 +258,13 @@
 	}
 
 	function StartSchedules() {
-		/*
-		_schedule.scheduleJob(CRON_CSV_WRITE_SCHEDULE, () => {
-			_dbo.AddToCsv();
-		});
-		_schedule.scheduleJob(CRON_ARCHIVE_SCHEDULE, () => {
-			_dbo.CreateArchives();
-		});
-		_schedule.scheduleJob(CRON_DB_REFRESH_SCHEDULE, () => {
-			_dbo.RefreshDatabase();
-		});
-		*/
 
 		CreateSchedule(CRON_CSV_WRITE_SCHEDULE, _dbo.AddToCsv);
 		CreateSchedule(CRON_ARCHIVE_SCHEDULE, _dbo.CreateArchives);
 		CreateSchedule(CRON_DB_REFRESH_SCHEDULE, _dbo.RefreshDatabase);
 
 		function CreateSchedule(originalSchedule, executeFunction) {
+			// --This will add one minute to the schedule and try again if need b. It will rest to default on success.
 			var newSchedule = originalSchedule;
 			var job = _schedule.scheduleJob(originalSchedule, () => {
 				job.cancel();
@@ -297,6 +287,7 @@
 		_wellTimerDisplay.write(_dto.MinutesAsHoursMins(_newData[_mapping.WELL_TIMER]));
 		_ecobeeCfhCounterDisplay.write(_newData[_mapping.CFH_COUNTER]);
 
+		// --Force the well to be fully charged on a total restart
 		if (_newData[_mapping.WELL_RECHARGE_TIMER] === 0)
 			_newData[_mapping.WELL_RECHARGE_TIMER] = RECHARGE_TIME_MINUTES;
 

--- a/bin/program.js
+++ b/bin/program.js
@@ -275,7 +275,8 @@
 				File operations while there's a chance of reading/writing to them can be dangerous. 
 				If there is a call for heat or the well is not charged the system is most likely reading/writing data, and
 					if this happens when one of the schedules are to run there is a chance that something will break, which is 
-					super not good. This will contrinue to try and run the schedule a minute later and will continue to do so.
+					not good. 
+				This method will contrinue to try and run the schedule every minute after the initial run.
 				It will rest to default on success.
 			*/
 			var newSchedule = originalSchedule;


### PR DESCRIPTION
Schedules will now only execute if there is not a call for gas and the well is recharged. This is because if those two conditions are not true, then there is a high chance that the system is reading/writing to files, so any kind of file deleting/manipulation is not recommended.

In addition: 
- If the db gets deleted, a new one will be created without touching the csv file, unless the csv file was deleted as well.
- If the db gets goofed up (cleared), PM2 will restart the process since something will error, and on startup a new db will be created. Any data that was in the deleted db will be lost, but the system will not break.