### PR TITLE
Local Server and Call For Heat Timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 - This project is a RPi3 replacement for the basement PLC gas-switching system with added features. 
 - Uses [Blynk](http://www.blynk.cc/) for monitoring and control and JavaScript (via [Node.Js](https://nodejs.org/en/)) as the language of choice.
 - The Pi's timezone must be manually set for task scheduling to work as expected. Follow [these](https://victorhurdugaci.com/raspberry-pi-sync-date-and-time) instructions for getting it set up.
-- This project is configured to run on a Blynk server hosted on the same Pi. Instructions for this are [here]https://github.com/blynkkk/blynk-server#blynk-server). All of the default ports are used.
+- This project is configured to run on a Blynk server hosted on the same Pi. Instructions for this are [here](https://github.com/blynkkk/blynk-server#blynk-server). All of the default ports are used.
 	- The admin portal is at `https://IP_OF_PI:9443/admin`
 	- The port to use in the Blynk app is 8442
 	- An admin user will be created the first time the server is run

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 - This project is a RPi3 replacement for the basement PLC gas-switching system with added features. 
 - Uses [Blynk](http://www.blynk.cc/) for monitoring and control and JavaScript (via [Node.Js](https://nodejs.org/en/)) as the language of choice.
 - The Pi's timezone must be manually set for task scheduling to work as expected. Follow [these](https://victorhurdugaci.com/raspberry-pi-sync-date-and-time) instructions for getting it set up.
+- This project is configured to run on a Blynk server hosted on the same Pi. Instructions for this are [here]https://github.com/blynkkk/blynk-server#blynk-server). All of the default ports are used.
+	- The admin portal is at `https://IP_OF_PI:9443/admin`
+	- The port to use in the Blynk app is 8442
+	- An admin user will be created the first time the server is run
 
 ## Installation
 - Clone this repo with SSH or HTTPS, then change directory into the `bin` folder

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -17,7 +17,7 @@ sudo npm install pm2 -g
 sudo npm install
 
 # --Finishing up
-echo -e "\n${GREEN}Install is complete!${NC}\nEnter your ${GREEN}Blynk Auth Token${NC}. This will be in an email from Blynk."
+echo -e "\n${GREEN}Install is complete!${NC}\nEnter your ${GREEN}Blynk Auth Token${NC}. This can be found in the Blynk app or in an email from Blynk."
 read authToken
 
 blynkAuthTemplate="module.exports = { GetAuth: function() { return \"$authToken\"; } }"

--- a/bin/program.js
+++ b/bin/program.js
@@ -75,7 +75,7 @@
 					timerRunning = true;
 					var i = 0;
 					cfhTimer = StartTimer(() => {
-						_ecobeeCfhCounterDisplay.write(++i);
+						_ecobeeCfhCounterDisplay.write(_dto.MinutesAsHoursMins(++i));
 					}, ALL_TIMERS_INTERVAL_MILLI);
 				}
 			} else {
@@ -84,7 +84,7 @@
 				DisableRelayAndLed(_boilerStartRelayOutput, _ecobeeCfhLed);
 				StopTimer(cfhTimer);
 				timerRunning = false;
-				_ecobeeCfhCounterDisplay.write(0);
+				_ecobeeCfhCounterDisplay.write(_dto.MinutesAsHoursMins(0));
 			} 
 		}, INPUT_CHECK_INTERVAL_MILLI);
 	}
@@ -321,7 +321,7 @@
 			_data[_mapping.WELL_RECHARGE_TIMER] = RECHARGE_TIME_MINUTES;
 
 		_wellRechargeTimerDisplay.write(_data[_mapping.WELL_RECHARGE_TIMER]);
-		_ecobeeCfhCounterDisplay.write(0);
+		_ecobeeCfhCounterDisplay.write(_dto.MinutesAsHoursMins(0));
 	}
 
 	function ResetSystemToZero() {

--- a/bin/program.js
+++ b/bin/program.js
@@ -1,12 +1,15 @@
 
 (function() {
-	var blynkLibrary = require('blynk-library');
-	var blynkAuth = require('./blynk-auth').GetAuth();
-	var _blynk = new blynkLibrary.Blynk(blynkAuth);
 	var _gpio = require('onoff').Gpio;
 	var _schedule = require('node-schedule');
 	var _dbo = require('./database-operations');
 	var _dto = require('./date-time-operations');
+
+	var blynkLibrary = require('blynk-library');
+	var blynkAuth = require('./blynk-auth').GetAuth();
+	var _blynk = new blynkLibrary.Blynk(blynkAuth, options = {
+		connector: new blynkLibrary.TcpClient(
+			options = { addr: '127.0.0.1', port: 8442 })});
 
 	const RECHARGE_TIME_MINUTES = 90;
 	const ALL_TIMERS_INTERVAL_MILLI = 60000;

--- a/bin/program.js
+++ b/bin/program.js
@@ -1,12 +1,12 @@
 
 (function() {
-	var	blynkLibrary = require('blynk-library');
-	var	blynkAuth = require('./blynk-auth').GetAuth();
-	var	_blynk = new blynkLibrary.Blynk(blynkAuth);
-	var	_gpio = require('onoff').Gpio;
-	var	_schedule = require('node-schedule');
-	var	_dbo = require('./database-operations');
-	var	_dto = require('./date-time-operations');
+	var blynkLibrary = require('blynk-library');
+	var blynkAuth = require('./blynk-auth').GetAuth();
+	var _blynk = new blynkLibrary.Blynk(blynkAuth);
+	var _gpio = require('onoff').Gpio;
+	var _schedule = require('node-schedule');
+	var _dbo = require('./database-operations');
+	var _dto = require('./date-time-operations');
 
 	const RECHARGE_TIME_MINUTES = 90;
 	const ALL_TIMERS_INTERVAL_MILLI = 60000;
@@ -16,25 +16,25 @@
 	const CRON_DB_REFRESH_SCHEDULE = '0 0 2-31 */1 *'; // --Every 2-31 days of the month at 12:00 am
 	const CRON_RESET_SCHEDULE = '0 0 1 7 *'; // --The 1st of July every year at 12:00 am
 
-	var	_manualOverrideButton = new _blynk.VirtualPin(0); 
-	var	_manualColumbiaButton = new _blynk.VirtualPin(1); 
-	var	_manualWellButton = new _blynk.VirtualPin(2);
-	var	_wellRechargeTimerDisplay = new _blynk.VirtualPin(3); 
-	var	_wellRechargeCounterDisplay = new _blynk.VirtualPin(4);
-	var	_columbiaTimerDisplay = new _blynk.VirtualPin(5);
-	var	_usingColumbiaLed = new _blynk.WidgetLED(6);
-	var	_wellTimerDisplay = new _blynk.VirtualPin(7);
-	var	_usingWellLed = new _blynk.WidgetLED(8);
-	var	_ecobeeCfhCounterDisplay = new _blynk.VirtualPin(9);
-	var	_ecobeeCfhLed = new _blynk.WidgetLED(10);
-	var	_boilerCfgLed = new _blynk.WidgetLED(11);
+	var _manualOverrideButton = new _blynk.VirtualPin(0); 
+	var _manualColumbiaButton = new _blynk.VirtualPin(1); 
+	var _manualWellButton = new _blynk.VirtualPin(2);
+	var _wellRechargeTimerDisplay = new _blynk.VirtualPin(3); 
+	var _wellRechargeCounterDisplay = new _blynk.VirtualPin(4);
+	var _columbiaTimerDisplay = new _blynk.VirtualPin(5);
+	var _usingColumbiaLed = new _blynk.WidgetLED(6);
+	var _wellTimerDisplay = new _blynk.VirtualPin(7);
+	var _usingWellLed = new _blynk.WidgetLED(8);
+	var _ecobeeCfhCounterDisplay = new _blynk.VirtualPin(9);
+	var _ecobeeCfhLed = new _blynk.WidgetLED(10);
+	var _boilerCfgLed = new _blynk.WidgetLED(11);
 
-	var	_wellPressureSwitchInput = new _gpio(26, 'in', 'both');
-	var	_boilerCfgInput = new _gpio(13, 'in', 'both');
-	var	_ecobeeCfhInput = new _gpio(16, 'in', 'both');
-	var	_columbiaValveRelayOutput = new _gpio(4, 'high');
-	var	_wellValveRelayOutput = new _gpio(17, 'high');
-	var	_boilerStartRelayOutput = new _gpio(27, 'high');
+	var _wellPressureSwitchInput = new _gpio(26, 'in', 'both');
+	var _boilerCfgInput = new _gpio(13, 'in', 'both');
+	var _ecobeeCfhInput = new _gpio(16, 'in', 'both');
+	var _columbiaValveRelayOutput = new _gpio(4, 'high');
+	var _wellValveRelayOutput = new _gpio(17, 'high');
+	var _boilerStartRelayOutput = new _gpio(27, 'high');
 
 	
 	var _mapping = require('./mapping').GetMapping();

--- a/bin/program.js
+++ b/bin/program.js
@@ -31,7 +31,7 @@
 	var _ecobeeCfhCounterDisplay = new _blynk.VirtualPin(9);
 	var _ecobeeCfhLed = new _blynk.WidgetLED(10);
 	var _boilerCfgLed = new _blynk.WidgetLED(11);
-	var _ecobeeCfhTimerDispaly = new _blynk.VirtualPin(12);
+	var _ecobeeCfhTimerDisplay = new _blynk.VirtualPin(12);
 
 	var _wellPressureSwitchInput = new _gpio(26, 'in', 'both');
 	var _boilerCfgInput = new _gpio(13, 'in', 'both');
@@ -78,7 +78,7 @@
 					timerRunning = true;
 					var i = 0;
 					cfhTimer = StartTimer(() => {
-						_ecobeeCfhCounterDisplay.write(_dto.MinutesAsHoursMins(++i));
+						_ecobeeCfhTimerDisplay.write(_dto.MinutesAsHoursMins(++i));
 					}, ALL_TIMERS_INTERVAL_MILLI);
 				}
 			} else {
@@ -87,7 +87,7 @@
 				DisableRelayAndLed(_boilerStartRelayOutput, _ecobeeCfhLed);
 				StopTimer(cfhTimer);
 				timerRunning = false;
-				_ecobeeCfhCounterDisplay.write(_dto.MinutesAsHoursMins(0));
+				_ecobeeCfhTimerDisplay.write(_dto.MinutesAsHoursMins(0));
 			} 
 		}, INPUT_CHECK_INTERVAL_MILLI);
 	}
@@ -324,7 +324,7 @@
 			_data[_mapping.WELL_RECHARGE_TIMER] = RECHARGE_TIME_MINUTES;
 
 		_wellRechargeTimerDisplay.write(_data[_mapping.WELL_RECHARGE_TIMER]);
-		_ecobeeCfhCounterDisplay.write(_dto.MinutesAsHoursMins(0));
+		_ecobeeCfhTimerDisplay.write(_dto.MinutesAsHoursMins(0));
 	}
 
 	function ResetSystemToZero() {


### PR DESCRIPTION
The project no longer connects to Blynk's servers, instead is is configured to connect to a local server hosted on the pi. At this point, the server is set to use the default options. This gives unlimited energy.

A call for heat timer display was also created to show the current call for heat duration.
