### PR TITLE
Blynk Wait for Server and Log Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 **/blynk-auth.js
+**/blynk-errors.txt
+**/test.js
+
 **/node_modules

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 - This project is a RPi3 replacement for the basement PLC gas-switching system with added features. 
 - Uses [Blynk](http://www.blynk.cc/) for monitoring and control and JavaScript (via [Node.Js](https://nodejs.org/en/)) as the language of choice.
 - The Pi's timezone must be manually set for task scheduling to work as expected. Follow [these](https://victorhurdugaci.com/raspberry-pi-sync-date-and-time) instructions for getting it set up.
-- This project is configured to run on a Blynk server hosted on the same Pi. Instructions for this are [here](https://github.com/blynkkk/blynk-server#blynk-server). All of the default ports are used.
+- This project is configured to run on a Blynk server hosted on the same Pi. Instructions for this are [here](https://github.com/blynkkk/blynk-server#blynk-server). All of the default ports are used. This must be set up first.
 	- The admin portal is at `https://IP_OF_PI:9443/admin`
 	- The port to use in the Blynk app is 8442
 	- An admin user will be created the first time the server is run
+	- An auth token will be generated when connecting to the server from the app
 
 ## Installation
 - Clone this repo with SSH or HTTPS, then change directory into the `bin` folder

--- a/bin/blynk-setup.js
+++ b/bin/blynk-setup.js
@@ -1,0 +1,45 @@
+
+var _outerFunc = module.exports = {
+	Setup: function(callback) {
+		var _dto = require('./date-time-operations');
+		var _fs = require('fs');
+		var _logName = 'blynk-errors.txt';
+		var _tcpPortUsed = require('tcp-port-used');
+		var _blynkLibrary = require('blynk-library');
+		var _blynkAuth = require('./blynk-auth').GetAuth();
+
+		// --These must match the hardware plain tcp/ip port and the ip of the server
+		var blynkServerPort = 8442; //--8442 is the default
+		var blynkServerIp = 'localhost';
+
+		// --Blynk will only connect once the server is up and running
+		(function CheckForServerAndSetupBlynk() {
+			_tcpPortUsed.check(blynkServerPort, blynkServerIp).then((inUse) => {
+				if (!inUse)
+					CheckForServerAndSetupBlynk();
+				else {
+					blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
+						connector: new _blynkLibrary.TcpClient(
+							options = { addr: blynkServerIp, port: blynkServerPort })});
+
+					// --Catch Blynk errors and log them to a file. PM2 will take care of other issues
+					blynk.on('error', (blynkErr) => {
+						_fs.stat(_logName, (err, stats) => {
+							if (!stats || stats.size === 0)
+								_fs.closeSync(_fs.openSync(_logName, 'w'));
+
+							var stream = _fs.createWriteStream(_logName, { flags: 'a' });
+							stream.write(_dto.GetCurrentDate().WithTime() + ': ' + blynkErr);
+							stream.end('\n')
+						})
+					});
+
+					// --Small delay is necessary otherwise Blynk will error right away
+					setTimeout(() => {
+						callback(blynk);
+					}, 500);
+				}
+			});
+		})();
+	}
+}

--- a/bin/program.js
+++ b/bin/program.js
@@ -1,389 +1,357 @@
 
 (function() {
-	var tcpPortUsed = require('tcp-port-used');
-	var blynkLibrary = require('blynk-library');
-	var blynkAuth = require('./blynk-auth').GetAuth();
+	// --Setup Blynk in another file and pass it in to start the rest of the program
+	require('./blynk-setup').Setup((_blynk) => {
+		var _gpio = require('onoff').Gpio;
+		var _schedule = require('node-schedule');
+		var _dbo = require('./database-operations');
+		var _dto = require('./date-time-operations');
 
-	// --These must match the hardware plain tcp/ip port and the ip of the server
-	var blynkServerPort = 8442; //--8442 is the default
-	var blynkServerIp = 'localhost';
+		const RECHARGE_TIME_MINUTES = 90;
+		const ALL_TIMERS_INTERVAL_MILLI = 60000;
+		const INPUT_CHECK_INTERVAL_MILLI = 50;
+		const CRON_CSV_WRITE_SCHEDULE = '0 7,19 * * *'; // --Every day at 7 am/pm
+		const CRON_ARCHIVE_SCHEDULE = '0 0 1 1-6,8-12 *'; // --Every 1st of every month excluding July at 12:00 am
+		const CRON_DB_REFRESH_SCHEDULE = '0 0 2-31 */1 *'; // --Every 2-31 days of the month at 12:00 am
+		const CRON_RESET_SCHEDULE = '0 0 1 7 *'; // --The 1st of July every year at 12:00 am
 
-	CheckForServerAndRun();
+		var _manualOverrideButton = new _blynk.VirtualPin(0); 
+		var _manualColumbiaButton = new _blynk.VirtualPin(1); 
+		var _manualWellButton = new _blynk.VirtualPin(2);
+		var _wellRechargeTimerDisplay = new _blynk.VirtualPin(3); 
+		var _wellRechargeCounterDisplay = new _blynk.VirtualPin(4);
+		var _columbiaTimerDisplay = new _blynk.VirtualPin(5);
+		var _usingColumbiaLed = new _blynk.WidgetLED(6);
+		var _wellTimerDisplay = new _blynk.VirtualPin(7);
+		var _usingWellLed = new _blynk.WidgetLED(8);
+		var _ecobeeCfhCounterDisplay = new _blynk.VirtualPin(9);
+		var _ecobeeCfhLed = new _blynk.WidgetLED(10);
+		var _boilerCfgLed = new _blynk.WidgetLED(11);
+		var _ecobeeCfhTimerDisplay = new _blynk.VirtualPin(12);
+		var _systemUptimeTimerDisplay = new _blynk.VirtualPin(13);
+		var _BoilerOfftimeTimerDisplay = new _blynk.VirtualPin(14);
 
-	// --Blynk will only connect once the server is up and running
-	function CheckForServerAndRun() {
-		tcpPortUsed.check(blynkServerPort, blynkServerIp).then((inUse) => {
-			if (!inUse)
-				CheckForServerAndRun();
-			else {
-				blynk = new blynkLibrary.Blynk(blynkAuth, options = {
-					connector: new blynkLibrary.TcpClient(
-						options = { addr: blynkServerIp, port: blynkServerPort })});
-
-				blynk.on('error', (err) => {
-					// --Handle the error but don't do anything with it right now
-				});
-
-				// --Small delay is necessary otherwise Blynk will error right away
-				setTimeout(() => {
-					Run(blynk);
-				}, 500);
-			}
-		})
-	}
-})();
-
-function Run(_blynk) {
-	var _gpio = require('onoff').Gpio;
-	var _schedule = require('node-schedule');
-	var _dbo = require('./database-operations');
-	var _dto = require('./date-time-operations');
-
-	const RECHARGE_TIME_MINUTES = 90;
-	const ALL_TIMERS_INTERVAL_MILLI = 60000;
-	const INPUT_CHECK_INTERVAL_MILLI = 50;
-	const CRON_CSV_WRITE_SCHEDULE = '0 7,19 * * *'; // --Every day at 7 am/pm
-	const CRON_ARCHIVE_SCHEDULE = '0 0 1 1-6,8-12 *'; // --Every 1st of every month excluding July at 12:00 am
-	const CRON_DB_REFRESH_SCHEDULE = '0 0 2-31 */1 *'; // --Every 2-31 days of the month at 12:00 am
-	const CRON_RESET_SCHEDULE = '0 0 1 7 *'; // --The 1st of July every year at 12:00 am
-
-	var _manualOverrideButton = new _blynk.VirtualPin(0); 
-	var _manualColumbiaButton = new _blynk.VirtualPin(1); 
-	var _manualWellButton = new _blynk.VirtualPin(2);
-	var _wellRechargeTimerDisplay = new _blynk.VirtualPin(3); 
-	var _wellRechargeCounterDisplay = new _blynk.VirtualPin(4);
-	var _columbiaTimerDisplay = new _blynk.VirtualPin(5);
-	var _usingColumbiaLed = new _blynk.WidgetLED(6);
-	var _wellTimerDisplay = new _blynk.VirtualPin(7);
-	var _usingWellLed = new _blynk.WidgetLED(8);
-	var _ecobeeCfhCounterDisplay = new _blynk.VirtualPin(9);
-	var _ecobeeCfhLed = new _blynk.WidgetLED(10);
-	var _boilerCfgLed = new _blynk.WidgetLED(11);
-	var _ecobeeCfhTimerDisplay = new _blynk.VirtualPin(12);
-	var _systemUptimeTimerDisplay = new _blynk.VirtualPin(13);
-	var _BoilerOfftimeTimerDisplay = new _blynk.VirtualPin(14);
-
-	var _wellPressureSwitchInput = new _gpio(26, 'in', 'both');
-	var _boilerCfgInput = new _gpio(13, 'in', 'both');
-	var _ecobeeCfhInput = new _gpio(16, 'in', 'both');
-	var _columbiaValveRelayOutput = new _gpio(4, 'high');
-	var _wellValveRelayOutput = new _gpio(17, 'high');
-	var _boilerStartRelayOutput = new _gpio(27, 'high');
-	
-	var _mapping = require('./mapping').GetMapping();
-	var _data;
-	var _isWellCharged;
-	var _isCallForHeat = false;
-	var _manualOverrideEnable = false;
-
-	// --Start main function
-	_dbo.LoadDatabase((data) => {
-		_data = data;
-
-		// --All functions split up for readability
-		InitializeValues();
-		StartSchedules();
-		MonitorEcobeeCallForHeat();
-		MonitorWellPressureSwitch();
-		MonitorValvesAndCallForGas();
-	});
-	// --End main function
-
-	function MonitorEcobeeCallForHeat() {
-		var countLogged = false;
-		var cfhTimerRunning = false;
-		var cfhTimer;
-		var boilerOfftimeTimerRunning = false;
-		var boilerOfftimeTimer;
-		StartTimer(() => {
-			if (_ecobeeCfhInput.readSync() === 1 && !_manualOverrideEnable) {
-				if (!countLogged) {
-					AddToDatabaseAndDisplay(_ecobeeCfhCounterDisplay, ++_data[_mapping.CFH_COUNTER]);
-					countLogged = true;
-				}
-				_isCallForHeat = true;
-				EnableRelayAndLed(_boilerStartRelayOutput, _ecobeeCfhLed);
-				StopTimer(boilerOfftimeTimer);
-				boilerOfftimeTimerRunning = false;
-				_BoilerOfftimeTimerDisplay.write(PrettyPrint(0));
-				if (!cfhTimerRunning) {
-					cfhTimerRunning = true;
-					var i = 0;
-					cfhTimer = StartTimer(() => {
-						_ecobeeCfhTimerDisplay.write(PrettyPrint(++i));
-					}, ALL_TIMERS_INTERVAL_MILLI);
-				}
-			} else {
-				if (!boilerOfftimeTimerRunning) {
-					boilerOfftimeTimerRunning = true;
-					var i = 0;
-					boilerOfftimeTimer = StartTimer(() => {
-						_BoilerOfftimeTimerDisplay.write(PrettyPrint(++i));
-					}, ALL_TIMERS_INTERVAL_MILLI)
-				}
-				countLogged = false;
-				_isCallForHeat = false;
-				DisableRelayAndLed(_boilerStartRelayOutput, _ecobeeCfhLed);
-				StopTimer(cfhTimer);
-				cfhTimerRunning = false;
-				_ecobeeCfhTimerDisplay.write(PrettyPrint(0));
-			} 
-
-		}, INPUT_CHECK_INTERVAL_MILLI);
-	}
-
-	function MonitorWellPressureSwitch() {
-		_isWellCharged = (_data[_mapping.WELL_RECHARGE_TIMER] === RECHARGE_TIME_MINUTES);
+		var _wellPressureSwitchInput = new _gpio(26, 'in', 'both');
+		var _boilerCfgInput = new _gpio(13, 'in', 'both');
+		var _ecobeeCfhInput = new _gpio(16, 'in', 'both');
+		var _columbiaValveRelayOutput = new _gpio(4, 'high');
+		var _wellValveRelayOutput = new _gpio(17, 'high');
+		var _boilerStartRelayOutput = new _gpio(27, 'high');
 		
-		var wellRechargeTimer;
-		var wellRechargeTimerRunning = false;
-		StartTimer(() => {
-			if (_wellPressureSwitchInput.readSync() === 1 && !wellRechargeTimerRunning && _data[_mapping.WELL_RECHARGE_TIMER] !== RECHARGE_TIME_MINUTES) {
-				_isWellCharged = false;
-				wellRechargeTimerRunning = true;
+		var _mapping = require('./mapping').GetMapping();
+		var _data;
+		var _isWellCharged;
+		var _isCallForHeat = false;
+		var _manualOverrideEnable = false;
 
-				wellRechargeTimer = StartTimer(() => {
-					AddToDatabaseAndDisplay(_wellRechargeTimerDisplay, ++_data[_mapping.WELL_RECHARGE_TIMER]);
+		// --Start main function
+		_dbo.LoadDatabase((data) => {
+			_data = data;
 
-					if (_data[_mapping.WELL_RECHARGE_TIMER] === RECHARGE_TIME_MINUTES) {
-						_isWellCharged = true;
-						StopTimer(wellRechargeTimer);
-						AddToDatabaseAndDisplay(_wellRechargeCounterDisplay, ++_data[_mapping.WELL_RECHARGE_COUNTER]);
-					} 
-				}, ALL_TIMERS_INTERVAL_MILLI);
-			} 
-			else if (_wellPressureSwitchInput.readSync() === 0) {
-				if (_data[_mapping.WELL_RECHARGE_TIMER] === RECHARGE_TIME_MINUTES)
-					_data[_mapping.WELL_RECHARGE_TIMER] = 0;
-				StopTimer(wellRechargeTimer);
-				wellRechargeTimerRunning = false;
-				_isWellCharged = false;
-			}
-		}, INPUT_CHECK_INTERVAL_MILLI);
-	}
+			// --All functions split up for readability
+			InitializeValues();
+			StartSchedules();
+			MonitorEcobeeCallForHeat();
+			MonitorWellPressureSwitch();
+			MonitorValvesAndCallForGas();
+		});
+		// --End main function
 
-	function MonitorValvesAndCallForGas() {
-		var boilerTimer;
-		var wellTimer;
-		var wellTimerRunning = false;
-		var wellManualValve = false;
-		var columbiaTimer;
-		var columbiaTimerRunning = false;
-		var columbiaManualValve = false;
-		var isCallForGas = false;
-
-
-		MonitorManualValveOverrideButton();
-		MonitorBoilerCallForGas();
-		ManualColumbiaValveControl();
-		ManualWellValveControl();
-
-		function MonitorManualValveOverrideButton() {
-			_manualOverrideButton.on('write', (value) => {
-				if (!_isCallForHeat) {
-					if (parseInt(value) === 1)
-						_manualOverrideEnable = true;
-					else {
-						_manualOverrideEnable = false;
-						_manualColumbiaButton.write(0);
-						_manualWellButton.write(0);
-						StopBothColumbiaAndWell();
+		function MonitorEcobeeCallForHeat() {
+			var countLogged = false;
+			var cfhTimerRunning = false;
+			var cfhTimer;
+			var boilerOfftimeTimerRunning = false;
+			var boilerOfftimeTimer;
+			StartTimer(() => {
+				if (_ecobeeCfhInput.readSync() === 1 && !_manualOverrideEnable) {
+					if (!countLogged) {
+						AddToDatabaseAndDisplay(_ecobeeCfhCounterDisplay, ++_data[_mapping.CFH_COUNTER]);
+						countLogged = true;
 					}
-				}
-				else
-					_manualOverrideButton.write(0);
-			});
+					_isCallForHeat = true;
+					EnableRelayAndLed(_boilerStartRelayOutput, _ecobeeCfhLed);
+					StopTimer(boilerOfftimeTimer);
+					boilerOfftimeTimerRunning = false;
+					_BoilerOfftimeTimerDisplay.write(PrettyPrint(0));
+					if (!cfhTimerRunning) {
+						cfhTimerRunning = true;
+						var i = 0;
+						cfhTimer = StartTimer(() => {
+							_ecobeeCfhTimerDisplay.write(PrettyPrint(++i));
+						}, ALL_TIMERS_INTERVAL_MILLI);
+					}
+				} else {
+					if (!boilerOfftimeTimerRunning) {
+						boilerOfftimeTimerRunning = true;
+						var i = 0;
+						boilerOfftimeTimer = StartTimer(() => {
+							_BoilerOfftimeTimerDisplay.write(PrettyPrint(++i));
+						}, ALL_TIMERS_INTERVAL_MILLI)
+					}
+					countLogged = false;
+					_isCallForHeat = false;
+					DisableRelayAndLed(_boilerStartRelayOutput, _ecobeeCfhLed);
+					StopTimer(cfhTimer);
+					cfhTimerRunning = false;
+					_ecobeeCfhTimerDisplay.write(PrettyPrint(0));
+				} 
+
+			}, INPUT_CHECK_INTERVAL_MILLI);
 		}
 
-		function MonitorBoilerCallForGas() {
-			var timerRunning = false;
+		function MonitorWellPressureSwitch() {
+			_isWellCharged = (_data[_mapping.WELL_RECHARGE_TIMER] === RECHARGE_TIME_MINUTES);
+			
+			var wellRechargeTimer;
+			var wellRechargeTimerRunning = false;
 			StartTimer(() => {
-				if (!_manualOverrideEnable) {
-					if (_boilerCfgInput.readSync() === 1 && !timerRunning) {
-						timerRunning = true;
-						StopTimer(boilerTimer);
-						boilerTimer = StartTimer(() => {
-							_boilerCfgLed.turnOn();
-							isCallForGas = true;
-							if (_isWellCharged) 
-								StartWellStopColumbia();
-							else 
-								StartColumbiaStopWell();
-						}, 100);
-					} else if (_boilerCfgInput.readSync() === 0) {
-						timerRunning = false;
-						StopBothColumbiaAndWell();
-						StopTimer(boilerTimer);
-						_boilerCfgLed.turnOff();
-						isCallForGas = false;
-					}
+				if (_wellPressureSwitchInput.readSync() === 1 && !wellRechargeTimerRunning && _data[_mapping.WELL_RECHARGE_TIMER] !== RECHARGE_TIME_MINUTES) {
+					_isWellCharged = false;
+					wellRechargeTimerRunning = true;
+
+					wellRechargeTimer = StartTimer(() => {
+						AddToDatabaseAndDisplay(_wellRechargeTimerDisplay, ++_data[_mapping.WELL_RECHARGE_TIMER]);
+
+						if (_data[_mapping.WELL_RECHARGE_TIMER] === RECHARGE_TIME_MINUTES) {
+							_isWellCharged = true;
+							StopTimer(wellRechargeTimer);
+							AddToDatabaseAndDisplay(_wellRechargeCounterDisplay, ++_data[_mapping.WELL_RECHARGE_COUNTER]);
+						} 
+					}, ALL_TIMERS_INTERVAL_MILLI);
+				} 
+				else if (_wellPressureSwitchInput.readSync() === 0) {
+					if (_data[_mapping.WELL_RECHARGE_TIMER] === RECHARGE_TIME_MINUTES)
+						_data[_mapping.WELL_RECHARGE_TIMER] = 0;
+					StopTimer(wellRechargeTimer);
+					wellRechargeTimerRunning = false;
+					_isWellCharged = false;
 				}
 			}, INPUT_CHECK_INTERVAL_MILLI);
 		}
 
-		function ManualColumbiaValveControl() {
-			_manualColumbiaButton.on('write', (value) => {
-				if (_manualOverrideEnable) {
-					if (parseInt(value) === 1) {
-						columbiaManualValve = true;
-						StartColumbiaStopWell();
-						_manualWellButton.write(0);
-					}
-					else {
-						columbiaManualValve = false;
-						StopBothColumbiaAndWell();
-					}
-				} else
-					_manualColumbiaButton.write(0);
-			});
-		}
+		function MonitorValvesAndCallForGas() {
+			var boilerTimer;
+			var wellTimer;
+			var wellTimerRunning = false;
+			var wellManualValve = false;
+			var columbiaTimer;
+			var columbiaTimerRunning = false;
+			var columbiaManualValve = false;
+			var isCallForGas = false;
 
-		function ManualWellValveControl() {
-			_manualWellButton.on('write', (value) => {
-				if (_manualOverrideEnable) {
-					if (parseInt(value) === 1) {
-						wellManualValve = true;
-						StartWellStopColumbia();
+
+			MonitorManualValveOverrideButton();
+			MonitorBoilerCallForGas();
+			ManualColumbiaValveControl();
+			ManualWellValveControl();
+
+			function MonitorManualValveOverrideButton() {
+				_manualOverrideButton.on('write', (value) => {
+					if (!_isCallForHeat) {
+						if (parseInt(value) === 1)
+							_manualOverrideEnable = true;
+						else {
+							_manualOverrideEnable = false;
+							_manualColumbiaButton.write(0);
+							_manualWellButton.write(0);
+							StopBothColumbiaAndWell();
+						}
+					}
+					else
+						_manualOverrideButton.write(0);
+				});
+			}
+
+			function MonitorBoilerCallForGas() {
+				var timerRunning = false;
+				StartTimer(() => {
+					if (!_manualOverrideEnable) {
+						if (_boilerCfgInput.readSync() === 1 && !timerRunning) {
+							timerRunning = true;
+							StopTimer(boilerTimer);
+							boilerTimer = StartTimer(() => {
+								_boilerCfgLed.turnOn();
+								isCallForGas = true;
+								if (_isWellCharged) 
+									StartWellStopColumbia();
+								else 
+									StartColumbiaStopWell();
+							}, 100);
+						} else if (_boilerCfgInput.readSync() === 0) {
+							timerRunning = false;
+							StopBothColumbiaAndWell();
+							StopTimer(boilerTimer);
+							_boilerCfgLed.turnOff();
+							isCallForGas = false;
+						}
+					}
+				}, INPUT_CHECK_INTERVAL_MILLI);
+			}
+
+			function ManualColumbiaValveControl() {
+				_manualColumbiaButton.on('write', (value) => {
+					if (_manualOverrideEnable) {
+						if (parseInt(value) === 1) {
+							columbiaManualValve = true;
+							StartColumbiaStopWell();
+							_manualWellButton.write(0);
+						}
+						else {
+							columbiaManualValve = false;
+							StopBothColumbiaAndWell();
+						}
+					} else
 						_manualColumbiaButton.write(0);
-					}
-					else {
-						wellManualValve = false;
-						StopBothColumbiaAndWell();
-					}
-				} else
-					_manualWellButton.write(0);
-			});
-		}
-
-		function StopBothColumbiaAndWell() {
-			columbiaManualValve = false;
-			wellManualValve = false;
-			columbiaTimerRunning = false;
-			wellTimerRunning = false;
-			StopTimer(wellTimer);
-			StopTimer(columbiaTimer);
-			DisableRelayAndLed(_wellValveRelayOutput, _usingWellLed);
-			DisableRelayAndLed(_columbiaValveRelayOutput, _usingColumbiaLed);
-		}
-
-		function StartWellStopColumbia() {
-			columbiaManualValve = false;
-			columbiaTimerRunning = false;
-			StopTimer(columbiaTimer);
-			EnableRelayAndLed(_wellValveRelayOutput, _usingWellLed);
-			DisableRelayAndLed(_columbiaValveRelayOutput, _usingColumbiaLed);
-			if (!wellTimerRunning && isCallForGas) {
-				wellTimerRunning = true;
-				wellTimer = StartTimer(() => {
-					AddToDatabaseAndDisplay(_wellTimerDisplay, ++_data[_mapping.WELL_TIMER], true);
-				}, ALL_TIMERS_INTERVAL_MILLI);
+				});
 			}
-		}
 
-		function StartColumbiaStopWell() {
-			wellManualValve = false;
-			wellTimerRunning = false;
-			StopTimer(wellTimer);
-			EnableRelayAndLed(_columbiaValveRelayOutput, _usingColumbiaLed);
-			DisableRelayAndLed(_wellValveRelayOutput, _usingWellLed);
-			if (!columbiaTimerRunning && isCallForGas) {
-				columbiaTimerRunning = true;
-				columbiaTimer = StartTimer(() => {
-					AddToDatabaseAndDisplay(_columbiaTimerDisplay, ++_data[_mapping.COLUMBIA_TIMER], true);
-				}, ALL_TIMERS_INTERVAL_MILLI);
+			function ManualWellValveControl() {
+				_manualWellButton.on('write', (value) => {
+					if (_manualOverrideEnable) {
+						if (parseInt(value) === 1) {
+							wellManualValve = true;
+							StartWellStopColumbia();
+							_manualColumbiaButton.write(0);
+						}
+						else {
+							wellManualValve = false;
+							StopBothColumbiaAndWell();
+						}
+					} else
+						_manualWellButton.write(0);
+				});
 			}
-		}
-	}
 
-	function StartTimer(functionToStart, loopTimeMilli) {
-		return setInterval(functionToStart, loopTimeMilli);
-	}
+			function StopBothColumbiaAndWell() {
+				columbiaManualValve = false;
+				wellManualValve = false;
+				columbiaTimerRunning = false;
+				wellTimerRunning = false;
+				StopTimer(wellTimer);
+				StopTimer(columbiaTimer);
+				DisableRelayAndLed(_wellValveRelayOutput, _usingWellLed);
+				DisableRelayAndLed(_columbiaValveRelayOutput, _usingColumbiaLed);
+			}
 
-	function StopTimer(timer) {
-		clearInterval(timer);
-	}
-
-	function EnableRelayAndLed(relay, led) {
-		relay.writeSync(0);
-		led.turnOn();
-	}
-
-	function DisableRelayAndLed(relay, led) {
-		relay.writeSync(1);
-		led.turnOff();
-	}
-
-	function AddToDatabaseAndDisplay(display, dataToAdd, prettyPrint) {
-		if (prettyPrint)
-			display.write(PrettyPrint(dataToAdd));
-		else
-			display.write(dataToAdd);
-		_dbo.AddToDatabase(_data, true);
-	}
-
-	function StartSchedules() {
-
-		CreateNormalSchedule(CRON_CSV_WRITE_SCHEDULE, _dbo.AddToCsv);
-
-		// --File safe schedueles will add a minute to the schedule and try again if the system could be reading or writing to a file
-		CreateFileSafeSchedule(CRON_RESET_SCHEDULE, ResetSystemToZero) // --Does not call _dbo directly
-		CreateFileSafeSchedule(CRON_ARCHIVE_SCHEDULE, _dbo.CreateArchives, () => {}); // --Empty callback is necessary
-		CreateFileSafeSchedule(CRON_DB_REFRESH_SCHEDULE, _dbo.RefreshDatabase);
-
-		function CreateFileSafeSchedule(originalSchedule, functionToStart, functionCallback) {
-			var newSchedule = originalSchedule;
-			var job = _schedule.scheduleJob(originalSchedule, () => {
-				job.cancel();
-				if (!_isCallForHeat && _isWellCharged) {
-					functionToStart(functionCallback);
-					job.reschedule(originalSchedule);
-				} else {
-					var arr = newSchedule.split(' ');
-					arr[0] = parseInt(arr[0]) + 1;
-					newSchedule = arr.join(' ');
-					job.reschedule(newSchedule);
+			function StartWellStopColumbia() {
+				columbiaManualValve = false;
+				columbiaTimerRunning = false;
+				StopTimer(columbiaTimer);
+				EnableRelayAndLed(_wellValveRelayOutput, _usingWellLed);
+				DisableRelayAndLed(_columbiaValveRelayOutput, _usingColumbiaLed);
+				if (!wellTimerRunning && isCallForGas) {
+					wellTimerRunning = true;
+					wellTimer = StartTimer(() => {
+						AddToDatabaseAndDisplay(_wellTimerDisplay, ++_data[_mapping.WELL_TIMER], true);
+					}, ALL_TIMERS_INTERVAL_MILLI);
 				}
+			}
+
+			function StartColumbiaStopWell() {
+				wellManualValve = false;
+				wellTimerRunning = false;
+				StopTimer(wellTimer);
+				EnableRelayAndLed(_columbiaValveRelayOutput, _usingColumbiaLed);
+				DisableRelayAndLed(_wellValveRelayOutput, _usingWellLed);
+				if (!columbiaTimerRunning && isCallForGas) {
+					columbiaTimerRunning = true;
+					columbiaTimer = StartTimer(() => {
+						AddToDatabaseAndDisplay(_columbiaTimerDisplay, ++_data[_mapping.COLUMBIA_TIMER], true);
+					}, ALL_TIMERS_INTERVAL_MILLI);
+				}
+			}
+		}
+
+		function StartTimer(functionToStart, loopTimeMilli) {
+			return setInterval(functionToStart, loopTimeMilli);
+		}
+
+		function StopTimer(timer) {
+			clearInterval(timer);
+		}
+
+		function EnableRelayAndLed(relay, led) {
+			relay.writeSync(0);
+			led.turnOn();
+		}
+
+		function DisableRelayAndLed(relay, led) {
+			relay.writeSync(1);
+			led.turnOff();
+		}
+
+		function AddToDatabaseAndDisplay(display, dataToAdd, prettyPrint) {
+			if (prettyPrint)
+				display.write(PrettyPrint(dataToAdd));
+			else
+				display.write(dataToAdd);
+			_dbo.AddToDatabase(_data, true);
+		}
+
+		function StartSchedules() {
+
+			CreateNormalSchedule(CRON_CSV_WRITE_SCHEDULE, _dbo.AddToCsv);
+
+			// --File safe schedueles will add a minute to the schedule and try again if the system could be reading or writing to a file
+			CreateFileSafeSchedule(CRON_RESET_SCHEDULE, ResetSystemToZero) // --Does not call _dbo directly
+			CreateFileSafeSchedule(CRON_ARCHIVE_SCHEDULE, _dbo.CreateArchives, () => {}); // --Empty callback is necessary
+			CreateFileSafeSchedule(CRON_DB_REFRESH_SCHEDULE, _dbo.RefreshDatabase);
+
+			function CreateFileSafeSchedule(originalSchedule, functionToStart, functionCallback) {
+				var newSchedule = originalSchedule;
+				var job = _schedule.scheduleJob(originalSchedule, () => {
+					job.cancel();
+					if (!_isCallForHeat && _isWellCharged) {
+						functionToStart(functionCallback);
+						job.reschedule(originalSchedule);
+					} else {
+						var arr = newSchedule.split(' ');
+						arr[0] = parseInt(arr[0]) + 1;
+						newSchedule = arr.join(' ');
+						job.reschedule(newSchedule);
+					}
+				});
+			}
+
+			function CreateNormalSchedule(schedule, functionToStart) {
+				_schedule.scheduleJob(schedule, () => {
+					functionToStart();
+				});
+			}
+		}
+
+		function InitializeValues() {
+			_wellRechargeCounterDisplay.write(_data[_mapping.WELL_RECHARGE_COUNTER]);
+			_columbiaTimerDisplay.write(PrettyPrint(_data[_mapping.COLUMBIA_TIMER]));
+			_wellTimerDisplay.write(PrettyPrint(_data[_mapping.WELL_TIMER]));
+			_ecobeeCfhCounterDisplay.write(_data[_mapping.CFH_COUNTER]);
+
+			// --Force the well to be fully charged on a total restart
+			if (_data[_mapping.WELL_RECHARGE_TIMER] === 0)
+				_data[_mapping.WELL_RECHARGE_TIMER] = RECHARGE_TIME_MINUTES;
+
+			_wellRechargeTimerDisplay.write(_data[_mapping.WELL_RECHARGE_TIMER]);
+			_ecobeeCfhTimerDisplay.write(PrettyPrint(0));
+
+			var i = 0;
+			_systemUptimeTimerDisplay.write(PrettyPrint(i));
+			StartTimer(() => {
+				_systemUptimeTimerDisplay.write(PrettyPrint(++i));
+			}, ALL_TIMERS_INTERVAL_MILLI);
+
+			_BoilerOfftimeTimerDisplay.write(PrettyPrint(0));
+		}
+
+		function ResetSystemToZero() {
+			_dbo.ResetSystemToZero((data) => {
+				_data = data;
+				InitializeValues();
 			});
 		}
 
-		function CreateNormalSchedule(schedule, functionToStart) {
-			_schedule.scheduleJob(schedule, () => {
-				functionToStart();
-			});
+		function PrettyPrint(min) {
+			return _dto.ConvertMinutesToHoursAndMintues(min).PrettyPrint();
 		}
-	}
-
-	function InitializeValues() {
-		_wellRechargeCounterDisplay.write(_data[_mapping.WELL_RECHARGE_COUNTER]);
-		_columbiaTimerDisplay.write(PrettyPrint(_data[_mapping.COLUMBIA_TIMER]));
-		_wellTimerDisplay.write(PrettyPrint(_data[_mapping.WELL_TIMER]));
-		_ecobeeCfhCounterDisplay.write(_data[_mapping.CFH_COUNTER]);
-
-		// --Force the well to be fully charged on a total restart
-		if (_data[_mapping.WELL_RECHARGE_TIMER] === 0)
-			_data[_mapping.WELL_RECHARGE_TIMER] = RECHARGE_TIME_MINUTES;
-
-		_wellRechargeTimerDisplay.write(_data[_mapping.WELL_RECHARGE_TIMER]);
-		_ecobeeCfhTimerDisplay.write(PrettyPrint(0));
-
-		var i = 0;
-		_systemUptimeTimerDisplay.write(PrettyPrint(i));
-		StartTimer(() => {
-			_systemUptimeTimerDisplay.write(PrettyPrint(++i));
-		}, ALL_TIMERS_INTERVAL_MILLI);
-
-		_BoilerOfftimeTimerDisplay.write(PrettyPrint(0));
-	}
-
-	function ResetSystemToZero() {
-		_dbo.ResetSystemToZero((data) => {
-			_data = data;
-			InitializeValues();
-		});
-	}
-
-	function PrettyPrint(min) {
-		return _dto.ConvertMinutesToHoursAndMintues(min).PrettyPrint();
-	}
-
-}
+	});
+})();

--- a/bin/program.js
+++ b/bin/program.js
@@ -3,7 +3,6 @@
 	var tcpPortUsed = require('tcp-port-used');
 	var blynkLibrary = require('blynk-library');
 	var blynkAuth = require('./blynk-auth').GetAuth();
-
 	// --These must match the hardware plain tcp/ip port and the ip of the server
 	var blynkServerPort = 8442;
 	var blynkServerIp = 'localhost';
@@ -11,21 +10,22 @@
 	PortCheck();
 
 	// --Blynk will only connect once the server is up and running
+	var _blynk;
 	function PortCheck() {
 		tcpPortUsed.check(blynkServerPort, blynkServerIp).then((inUse) => {
 			if (!inUse)
 				PortCheck();
 			else {
-				var blynk = new blynkLibrary.Blynk(blynkAuth, options = {
+				_blynk = new blynkLibrary.Blynk(blynkAuth, options = {
 					connector: new blynkLibrary.TcpClient(
 						options = { addr: blynkServerIp, port: blynkServerPort })});
-				RunProgram(blynk);
+				Run();
 			}
 		})
 	}
 })();
 
-function RunProgram(_blynk) {
+function Run() {
 	var _gpio = require('onoff').Gpio;
 	var _schedule = require('node-schedule');
 	var _dbo = require('./database-operations');

--- a/bin/program.js
+++ b/bin/program.js
@@ -3,29 +3,32 @@
 	var tcpPortUsed = require('tcp-port-used');
 	var blynkLibrary = require('blynk-library');
 	var blynkAuth = require('./blynk-auth').GetAuth();
+
 	// --These must match the hardware plain tcp/ip port and the ip of the server
-	var blynkServerPort = 8442;
+	var blynkServerPort = 8442; //--8442 is the default
 	var blynkServerIp = 'localhost';
 
-	PortCheck();
+	CheckForServerAndRun();
 
 	// --Blynk will only connect once the server is up and running
-	var _blynk;
-	function PortCheck() {
+	function CheckForServerAndRun() {
 		tcpPortUsed.check(blynkServerPort, blynkServerIp).then((inUse) => {
 			if (!inUse)
-				PortCheck();
+				CheckForServerAndRun();
 			else {
-				_blynk = new blynkLibrary.Blynk(blynkAuth, options = {
+				blynk = new blynkLibrary.Blynk(blynkAuth, options = {
 					connector: new blynkLibrary.TcpClient(
 						options = { addr: blynkServerIp, port: blynkServerPort })});
-				Run();
+				// --Small delay is necessary otherwise Blynk will error
+				setTimeout(() => {
+					Run(blynk);
+				}, 500)
 			}
 		})
 	}
 })();
 
-function Run() {
+function Run(_blynk) {
 	var _gpio = require('onoff').Gpio;
 	var _schedule = require('node-schedule');
 	var _dbo = require('./database-operations');

--- a/bin/program.js
+++ b/bin/program.js
@@ -19,10 +19,15 @@
 				blynk = new blynkLibrary.Blynk(blynkAuth, options = {
 					connector: new blynkLibrary.TcpClient(
 						options = { addr: blynkServerIp, port: blynkServerPort })});
-				// --Small delay is necessary otherwise Blynk will error
+
+				blynk.on('error', (err) => {
+					// --Handle the error but don't do anything with it right now
+				});
+
+				// --Small delay is necessary otherwise Blynk will error right away
 				setTimeout(() => {
 					Run(blynk);
-				}, 500)
+				}, 500);
 			}
 		})
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "RPi3-BoilerControl",
+  "name": "BoilerControl",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -45,6 +45,16 @@
         "generate-object-property": "1.2.0",
         "ndjson": "1.5.0"
       }
+    },
+    "debug": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+      "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+    },
+    "deep-is": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
+      "integrity": "sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg="
     },
     "define-properties": {
       "version": "1.1.2",
@@ -94,6 +104,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is2": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-0.0.9.tgz",
+      "integrity": "sha1-EZVW0dFlGkG6EFr4AyZ8gLKZ9ik=",
+      "requires": {
+        "deep-is": "0.1.2"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -3121,6 +3139,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "q": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+      "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
+    },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
@@ -3164,6 +3187,16 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
         "safe-buffer": "5.1.1"
+      }
+    },
+    "tcp-port-used": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-0.1.2.tgz",
+      "integrity": "sha1-lFDodoyDtBb9TRpqlEnuzL9JbCk=",
+      "requires": {
+        "debug": "0.7.4",
+        "is2": "0.0.9",
+        "q": "0.9.7"
       }
     },
     "through2": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "csv-write-stream": "^2.0.0",
     "node-schedule": "^1.2.5",
     "npm": "^5.4.2",
-    "onoff": "^1.1.7"
+    "onoff": "^1.1.7",
+    "tcp-port-used": "^0.1.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Looking through the PM2 log files, BoilerControl would be restarted ~8 times when starting for the first time. This was because the local server was being started at the same time, and Blynk was trying to connect to the server when it wasn't ready. This would cause Blynk to throw an error, and Blynk errors were not handled, which would cause a blow up and PM2 to restart it. To combat these issues:

- Blynk now waits for the local server to come online before connecting
- Blynk errors are handled by being logged to a file
  - Other uncaught errors will still be thrown and handled by PM2. The logging is just for informative purposes.