### PR TITLE
Include Local Server/Formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 **/blynk-auth.js
-**/blynk-errors.txt
 **/test.js
 **/Boiler Data
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 - This project is a RPi3 replacement for the basement PLC gas-switching system with added features. 
 - Uses [Blynk](http://www.blynk.cc/) for monitoring and control and JavaScript (via [Node.Js](https://nodejs.org/en/)) as the language of choice.
 - The Pi's timezone must be manually set for task scheduling to work as expected. Follow [these](https://victorhurdugaci.com/raspberry-pi-sync-date-and-time) instructions for getting it set up.
-- This project is configured to run on a Blynk server hosted on the same Pi. Instructions for this are [here](https://github.com/blynkkk/blynk-server#blynk-server). All of the default ports are used. This must be set up first.
-	- The admin portal is at `https://IP_OF_PI:9443/admin`
-	- The port to use in the Blynk app is 8442
-	- An admin user will be created the first time the server is run
-	- An auth token will be generated when connecting to the server from the app
+- This project is configured to run on a Blynk server hosted on the same Pi. Instructions for this are [here](https://github.com/blynkkk/blynk-server#blynk-server). The server is included with this project and will be started automatically. View the `server.properties` file for reference. Port forwarding of the `https.port` and the `hardware.default.port` is required.
+   - The admin portal is at `https://IP_OF_PI:https.port/admin`
+   - The port to use in the app is the `hardware.default.port`
+   - An admin user will be created the first time the server is run
+      - At the time of writing this the username is `admin@blynk.cc` and the password is `admin`
+   - An auth token will be generated when connecting to the server from the app
 
 ## Installation
 - Clone this repo with SSH or HTTPS, then change directory into the `bin` folder

--- a/bin/Blynk/Server/.gitignore
+++ b/bin/Blynk/Server/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!*.jar

--- a/bin/Blynk/Server/.gitignore
+++ b/bin/Blynk/Server/.gitignore
@@ -1,3 +1,4 @@
 *
 !.gitignore
 !*.jar
+!server.properties

--- a/bin/Blynk/Server/server.properties
+++ b/bin/Blynk/Server/server.properties
@@ -1,6 +1,8 @@
-#Default server options follow
+
+# Default server options follow
 app.ssl.port=8443
 hardware.default.port=8442
 hardware.ssl.port=8441
 https.port=9443
 http.port=8080
+# End default options

--- a/bin/Blynk/Server/server.properties
+++ b/bin/Blynk/Server/server.properties
@@ -1,8 +1,10 @@
-
 # Default server options follow
 app.ssl.port=8443
 hardware.default.port=8442
 hardware.ssl.port=8441
 https.port=9443
 http.port=8080
-# End default options
+-# End default options
+
+# Allows all ips to hit the admin page
+allowed.administrator.ips=0.0.0.0/0

--- a/bin/Blynk/Server/server.properties
+++ b/bin/Blynk/Server/server.properties
@@ -1,0 +1,6 @@
+#Default server options follow
+app.ssl.port=8443
+hardware.default.port=8442
+hardware.ssl.port=8441
+https.port=9443
+http.port=8080

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -12,7 +12,7 @@ var _outerFunc = module.exports = {
 			var blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
 			// --These must match the hardware plain tcp/ip port and the ip of the server
 			// --Change in serverDirectory/server.properties
-			var blynkServerPort = 8442; //--8442 is the default
+			var blynkServerPort = 8442;
 			var blynkServerIp = 'localhost';
 
 			var blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -7,7 +7,6 @@ module.exports = function (callback) {
 
 	var serverDirectory = __dirname + '/Server/';
 	StartServer(serverDirectory, () => {
-		var blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
 		// --These must match the hardware plain tcp/ip port and the ip of the server
 		// --Change in serverDirectory/server.properties
 		var blynkServerPort = 8442;
@@ -17,16 +16,9 @@ module.exports = function (callback) {
 			connector: new _blynkLibrary.TcpClient(
 				options = { addr: blynkServerIp, port: blynkServerPort })});
 
-		// --Catch Blynk errors and log them to a file. PM2 will take care of other issues
+		// --Throw any blynk errors so PM2 can restart the program and server
 		blynk.on('error', (blynkErr) => {
-			_fs.stat(blynkErrorLogNameWithPath, (err, stats) => {
-				if (!stats || stats.size === 0)
-					_fs.closeSync(_fs.openSync(blynkErrorLogNameWithPath, 'w'));
-
-				var stream = _fs.createWriteStream(blynkErrorLogNameWithPath, { flags: 'a' });
-				stream.write(_dto.GetCurrentDateAndTime() + ': ' + blynkErr);
-				stream.end('\n');
-			});
+			throw (blynkErr);
 		});
 
 		// --Small delay is necessary otherwise Blynk will error right away

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -5,16 +5,16 @@ module.exports = function (callback) {
 	var _blynkLibrary = require('blynk-library');
 	var _blynkAuth = requireLocal('blynk-auth').GetAuth();
 
-	var serverDirectory = __dirname + '/Server/';
-	StartServer(serverDirectory, () => {
+	const SERVER_DIRECTORY = __dirname + '/Server/';
+	StartServer(SERVER_DIRECTORY, () => {
 		// --These must match the hardware plain tcp/ip port and the ip of the server
-		// --Change in serverDirectory/server.properties
-		var blynkServerPort = 8442;
-		var blynkServerIp = 'localhost';
+		// --Change in SERVER_DIRECTORY/server.properties
+		const BLYNK_SERVER_PORT = 8442;
+		const BLYNK_SERVER_IP = 'localhost';
 
 		var blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
 			connector: new _blynkLibrary.TcpClient(
-				options = { addr: blynkServerIp, port: blynkServerPort })});
+				options = { addr: BLYNK_SERVER_IP, port: BLYNK_SERVER_PORT })});
 
 		// --Throw any blynk errors so PM2 can restart everything
 		blynk.on('error', (blynkErr) => {
@@ -27,10 +27,10 @@ module.exports = function (callback) {
 		}, 500);
 	});
 
-	// --Start the server by dynamically finding the correct server.jar file
 	function StartServer(dir, callback) {
 		var spawn = require('child_process').spawn;
 
+		// --Find the .jar file regardless of its name, avoids hardcoding the file name
 		var results = [];
 		var list = _fs.readdirSync(dir);
 		list.forEach((file) => {
@@ -41,6 +41,7 @@ module.exports = function (callback) {
 			return el.match(/.+(\.jar)/);
 		});
 
+		// --If no or more than one .jar is found, throw this, because we only need one
 		if (serverFiles.length !== 1)
 			throw ('Make sure only one server .jar is in ' + dir);
 

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -1,67 +1,64 @@
 
-var _outerFunc = module.exports = {
-	Setup: function(callback) {
-		var _dto = requireLocal('date-time-operations');
-		var _fs = require('fs');
-		var _tcpPortUsed = require('tcp-port-used');
-		var _blynkLibrary = require('blynk-library');
-		var _blynkAuth = requireLocal('blynk-auth').GetAuth();
+module.exports = function (callback) {
+	var _dto = requireLocal('date-time-operations');
+	var _fs = require('fs');
+	var _blynkLibrary = require('blynk-library');
+	var _blynkAuth = requireLocal('blynk-auth').GetAuth();
 
-		var serverDirectory = __dirname + '/Server/';
-		StartServer(serverDirectory, () => {
-			var blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
-			// --These must match the hardware plain tcp/ip port and the ip of the server
-			// --Change in serverDirectory/server.properties
-			var blynkServerPort = 8442;
-			var blynkServerIp = 'localhost';
+	var serverDirectory = __dirname + '/Server/';
+	StartServer(serverDirectory, () => {
+		var blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
+		// --These must match the hardware plain tcp/ip port and the ip of the server
+		// --Change in serverDirectory/server.properties
+		var blynkServerPort = 8442;
+		var blynkServerIp = 'localhost';
 
-			var blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
-				connector: new _blynkLibrary.TcpClient(
-					options = { addr: blynkServerIp, port: blynkServerPort })});
+		var blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
+			connector: new _blynkLibrary.TcpClient(
+				options = { addr: blynkServerIp, port: blynkServerPort })});
 
-			// --Catch Blynk errors and log them to a file. PM2 will take care of other issues
-			blynk.on('error', (blynkErr) => {
-				_fs.stat(blynkErrorLogNameWithPath, (err, stats) => {
-					if (!stats || stats.size === 0)
-						_fs.closeSync(_fs.openSync(blynkErrorLogNameWithPath, 'w'));
+		// --Catch Blynk errors and log them to a file. PM2 will take care of other issues
+		blynk.on('error', (blynkErr) => {
+			_fs.stat(blynkErrorLogNameWithPath, (err, stats) => {
+				if (!stats || stats.size === 0)
+					_fs.closeSync(_fs.openSync(blynkErrorLogNameWithPath, 'w'));
 
-					var stream = _fs.createWriteStream(blynkErrorLogNameWithPath, { flags: 'a' });
-					stream.write(_dto.GetCurrentDateAndTime() + ': ' + blynkErr);
-					stream.end('\n');
-				});
+				var stream = _fs.createWriteStream(blynkErrorLogNameWithPath, { flags: 'a' });
+				stream.write(_dto.GetCurrentDateAndTime() + ': ' + blynkErr);
+				stream.end('\n');
 			});
-
-			// --Small delay is necessary otherwise Blynk will error right away
-			setTimeout(() => {
-				callback(blynk);
-			}, 500);
 		});
 
-		// --Start the server by dynamically finding the correct server.jar file
-		function StartServer(dir, callback) {
-			var spawn = require('child_process').spawn;
+		// --Small delay is necessary otherwise Blynk will error right away
+		setTimeout(() => {
+			callback(blynk);
+		}, 500);
+	});
 
-			var results = [];
-			var list = _fs.readdirSync(dir);
-			list.forEach((file) => {
-				file = dir + '/' + file;
-				results.push(file);
-			});
-			var serverFile = results.filter((el) => {
-				return el.match(/.+(\.jar)/);
-			}).toString();
+	// --Start the server by dynamically finding the correct server.jar file
+	function StartServer(dir, callback) {
+		var spawn = require('child_process').spawn;
 
-			// --Must temporarily cd into the server dir before spawn and cd back
-			process.chdir(dir);
-			var server = spawn('java', ['-jar', serverFile, '-dataFolder', dir, '-serverConfig', dir + 'server.properties']);
-			process.chdir(__dirname);
+		var results = [];
+		var list = _fs.readdirSync(dir);
+		list.forEach((file) => {
+			file = dir + '/' + file;
+			results.push(file);
+		});
+		var serverFile = results.filter((el) => {
+			return el.match(/.+(\.jar)/);
+		}).toString();
 
-			server.stdout.on('data', (data) => {
-				data = data.toString();
-				// --Callback only when the server has actually started
-				if (data.includes('started'))
-					callback();
-			});
-		}
+		// --Must temporarily cd into the server dir before spawn and cd back
+		process.chdir(dir);
+		var server = spawn('java', ['-jar', serverFile, '-dataFolder', dir, '-serverConfig', dir + 'server.properties']);
+		process.chdir(__dirname);
+
+		server.stdout.on('data', (data) => {
+			data = data.toString();
+			// --Callback only when the server has actually started
+			if (data.includes('started'))
+				callback();
+		});
 	}
 }

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -16,7 +16,7 @@ module.exports = function (callback) {
 			connector: new _blynkLibrary.TcpClient(
 				options = { addr: blynkServerIp, port: blynkServerPort })});
 
-		// --Throw any blynk errors so PM2 can restart the program and server
+		// --Throw any blynk errors so PM2 can restart everything
 		blynk.on('error', (blynkErr) => {
 			throw (blynkErr);
 		});

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -11,6 +11,7 @@ var _outerFunc = module.exports = {
 		StartServer(serverDirectory, () => {
 			var blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
 			// --These must match the hardware plain tcp/ip port and the ip of the server
+			// --Change in serverDirectory/server.properties
 			var blynkServerPort = 8442; //--8442 is the default
 			var blynkServerIp = 'localhost';
 
@@ -50,7 +51,11 @@ var _outerFunc = module.exports = {
 				return el.match(/.+(\.jar)/);
 			}).toString();
 
-			var server = spawn('java', ['-jar', serverFile, '-dataFolder', dir]);
+			// --Must temporarily cd into the server dir before spawn and cd back
+			process.chdir(dir);
+			var server = spawn('java', ['-jar', serverFile, '-dataFolder', dir, '-serverConfig', dir + 'server.properties']);
+			process.chdir(__dirname);
+
 			server.stdout.on('data', (data) => {
 				data = data.toString();
 				// --Callback only when the server has actually started

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -8,14 +8,13 @@ var _outerFunc = module.exports = {
 		var _blynkAuth = requireLocal('blynk-auth').GetAuth();
 
 		var serverDirectory = __dirname + '/Server/';
-
 		StartServer(serverDirectory, () => {
 			var blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
 			// --These must match the hardware plain tcp/ip port and the ip of the server
 			var blynkServerPort = 8442; //--8442 is the default
 			var blynkServerIp = 'localhost';
-			
-			blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
+
+			var blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
 				connector: new _blynkLibrary.TcpClient(
 					options = { addr: blynkServerIp, port: blynkServerPort })});
 
@@ -37,6 +36,7 @@ var _outerFunc = module.exports = {
 			}, 500);
 		});
 
+		// --Start the server by dynamically finding the correct server.jar file
 		function StartServer(dir, callback) {
 			var spawn = require('child_process').spawn;
 
@@ -50,8 +50,13 @@ var _outerFunc = module.exports = {
 				return el.match(/.+(\.jar)/);
 			}).toString();
 
-			spawn('java', ['-jar', serverFile, '-dataFolder', dir]);
-			callback();
+			var server = spawn('java', ['-jar', serverFile, '-dataFolder', dir]);
+			server.stdout.on('data', (data) => {
+				data = data.toString();
+				// --Callback only when the server has actually started
+				if (data.includes('started'))
+					callback();
+			});
 		}
 	}
 }

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -7,40 +7,51 @@ var _outerFunc = module.exports = {
 		var _blynkLibrary = require('blynk-library');
 		var _blynkAuth = requireLocal('blynk-auth').GetAuth();
 
-		var _blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
+		var serverDirectory = __dirname + '/Server/';
 
-		// --These must match the hardware plain tcp/ip port and the ip of the server
-		var blynkServerPort = 8442; //--8442 is the default
-		var blynkServerIp = 'localhost';
+		StartServer(serverDirectory, () => {
+			var blynkErrorLogNameWithPath = __dirname + '/blynk-errors.txt';
+			// --These must match the hardware plain tcp/ip port and the ip of the server
+			var blynkServerPort = 8442; //--8442 is the default
+			var blynkServerIp = 'localhost';
+			
+			blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
+				connector: new _blynkLibrary.TcpClient(
+					options = { addr: blynkServerIp, port: blynkServerPort })});
 
-		// --Blynk will only connect once the server is up and running
-		(function CheckForServerAndSetupBlynk() {
-			_tcpPortUsed.check(blynkServerPort, blynkServerIp).then((inUse) => {
-				if (!inUse)
-					CheckForServerAndSetupBlynk();
-				else {
-					blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
-						connector: new _blynkLibrary.TcpClient(
-							options = { addr: blynkServerIp, port: blynkServerPort })});
+			// --Catch Blynk errors and log them to a file. PM2 will take care of other issues
+			blynk.on('error', (blynkErr) => {
+				_fs.stat(blynkErrorLogNameWithPath, (err, stats) => {
+					if (!stats || stats.size === 0)
+						_fs.closeSync(_fs.openSync(blynkErrorLogNameWithPath, 'w'));
 
-					// --Catch Blynk errors and log them to a file. PM2 will take care of other issues
-					blynk.on('error', (blynkErr) => {
-						_fs.stat(_blynkErrorLogNameWithPath, (err, stats) => {
-							if (!stats || stats.size === 0)
-								_fs.closeSync(_fs.openSync(_blynkErrorLogNameWithPath, 'w'));
-
-							var stream = _fs.createWriteStream(_blynkErrorLogNameWithPath, { flags: 'a' });
-							stream.write(_dto.GetCurrentDateAndTime() + ': ' + blynkErr);
-							stream.end('\n');
-						});
-					});
-
-					// --Small delay is necessary otherwise Blynk will error right away
-					setTimeout(() => {
-						callback(blynk);
-					}, 500);
-				}
+					var stream = _fs.createWriteStream(blynkErrorLogNameWithPath, { flags: 'a' });
+					stream.write(_dto.GetCurrentDateAndTime() + ': ' + blynkErr);
+					stream.end('\n');
+				});
 			});
-		})();
+
+			// --Small delay is necessary otherwise Blynk will error right away
+			setTimeout(() => {
+				callback(blynk);
+			}, 500);
+		});
+
+		function StartServer(dir, callback) {
+			var spawn = require('child_process').spawn;
+
+			var results = [];
+			var list = _fs.readdirSync(dir);
+			list.forEach((file) => {
+				file = dir + '/' + file;
+				results.push(file);
+			});
+			var serverFile = results.filter((el) => {
+				return el.match(/.+(\.jar)/);
+			}).toString();
+
+			spawn('java', ['-jar', serverFile, '-dataFolder', dir]);
+			callback();
+		}
 	}
 }

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -37,9 +37,14 @@ module.exports = function (callback) {
 			file = dir + '/' + file;
 			results.push(file);
 		});
-		var serverFile = results.filter((el) => {
+		var serverFiles = results.filter((el) => {
 			return el.match(/.+(\.jar)/);
-		}).toString();
+		});
+
+		if (serverFiles.length !== 1)
+			throw ('Make sure only one server .jar is in ' + dir);
+
+		var serverFile = serverFiles[0];
 
 		// --Must temporarily cd into the server dir before spawn and cd back
 		process.chdir(dir);

--- a/bin/Blynk/blynk-setup.js
+++ b/bin/Blynk/blynk-setup.js
@@ -1,22 +1,20 @@
 
 module.exports = function (callback) {
-	var _dto = requireLocal('date-time-operations');
-	var _fs = require('fs');
-	var _blynkLibrary = require('blynk-library');
-	var _blynkAuth = requireLocal('blynk-auth').GetAuth();
+	// --These must match the hardware plain tcp/ip port and the ip of the server
+	// --Change in SERVER_DIRECTORY/server.properties
+	const BLYNK_SERVER_PORT = 8442;
+	const BLYNK_SERVER_IP = 'localhost';
 
 	const SERVER_DIRECTORY = __dirname + '/Server/';
-	StartServer(SERVER_DIRECTORY, () => {
-		// --These must match the hardware plain tcp/ip port and the ip of the server
-		// --Change in SERVER_DIRECTORY/server.properties
-		const BLYNK_SERVER_PORT = 8442;
-		const BLYNK_SERVER_IP = 'localhost';
 
-		var blynk = new _blynkLibrary.Blynk(_blynkAuth, options = {
-			connector: new _blynkLibrary.TcpClient(
+	StartServer(SERVER_DIRECTORY, () => {
+		var blynkLibrary = require('blynk-library');
+		var blynkAuth = requireLocal('blynk-auth')();
+		
+		var blynk = new blynkLibrary.Blynk(blynkAuth, options = {
+			connector: new blynkLibrary.TcpClient(
 				options = { addr: BLYNK_SERVER_IP, port: BLYNK_SERVER_PORT })});
 
-		// --Throw any blynk errors so PM2 can restart everything
 		blynk.on('error', (blynkErr) => {
 			throw (blynkErr);
 		});
@@ -29,10 +27,11 @@ module.exports = function (callback) {
 
 	function StartServer(dir, callback) {
 		var spawn = require('child_process').spawn;
+		var fs = require('fs');
 
 		// --Find the .jar file regardless of its name, avoids hardcoding the file name
 		var results = [];
-		var list = _fs.readdirSync(dir);
+		var list = fs.readdirSync(dir);
 		list.forEach((file) => {
 			file = dir + '/' + file;
 			results.push(file);
@@ -41,7 +40,6 @@ module.exports = function (callback) {
 			return el.match(/.+(\.jar)/);
 		});
 
-		// --If no or more than one .jar is found, throw this, because we only need one
 		if (serverFiles.length !== 1)
 			throw ('Make sure only one server .jar is in ' + dir);
 
@@ -54,7 +52,6 @@ module.exports = function (callback) {
 
 		server.stdout.on('data', (data) => {
 			data = data.toString();
-			// --Callback only when the server has actually started
 			if (data.includes('started'))
 				callback();
 		});

--- a/bin/Operations/database-operations.js
+++ b/bin/Operations/database-operations.js
@@ -14,7 +14,7 @@ var _dbPathWithName;
 var _csvFileName = 'Boiler Data';
 var _csvPathWithName;
 
-var _mapping = requireLocal('mapping').GetMapping();
+var _mapping = requireLocal('mapping')();
 var _data;
 var _headers;
 

--- a/bin/Tests/database-tests.js
+++ b/bin/Tests/database-tests.js
@@ -7,7 +7,7 @@ global.requireLocal = require('local-modules').GetModule;
 	var	_rl = require('readline').createInterface({ input: process.stdin, output: process.stdout });
 	var	_dto = requireLocal('date-time-operations');
 
-	var _mapping = requireLocal('mapping').GetMapping();
+	var _mapping = requireLocal('mapping')();
 	var _data;
 
 	_dbo.LoadDatabase((data) => {

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -20,7 +20,7 @@ sudo npm install
 echo -e "\n${GREEN}Install is complete!${NC}\nEnter your ${GREEN}Blynk Auth Token${NC}. This can be found in the Blynk app or in an email from Blynk."
 read authToken
 
-blynkAuthTemplate="module.exports = { GetAuth: function() { return \"$authToken\"; } }"
+blynkAuthTemplate="module.exports = function() { return \"$authToken\"; }"
 echo "$blynkAuthTemplate" > Blynk/blynk-auth.js
 
 sudo chown pi -R $PWD

--- a/bin/mapping.js
+++ b/bin/mapping.js
@@ -1,16 +1,14 @@
 
 
-var _outerFunc = module.exports = {
-	GetMapping: function() {
-		// --Note: if the keys are renamed, other files that use this will have to be changed accordingly.
-		return {
-			DATE: 'Date',
-			WELL_TIMER: 'Well Timer',
-			COLUMBIA_TIMER: 'Columbia Timer',
-			WELL_RECHARGE_COUNTER: 'Well Counter',
-			CFH_COUNTER : 'Call For Heat Counter',
-			WELL_RECHARGE_TIMER: 'Well Recharge Timer',
-			WELL_SAVINGS: 'Cumulative Well Savings'
-		}
+module.exports = function() {
+	// --Note: if the keys are renamed, other files that use this will have to be changed accordingly.
+	return {
+		DATE: 'Date',
+		WELL_TIMER: 'Well Timer',
+		COLUMBIA_TIMER: 'Columbia Timer',
+		WELL_RECHARGE_COUNTER: 'Well Counter',
+		CFH_COUNTER : 'Call For Heat Counter',
+		WELL_RECHARGE_TIMER: 'Well Recharge Timer',
+		WELL_SAVINGS: 'Cumulative Well Savings'
 	}
 }

--- a/bin/program.js
+++ b/bin/program.js
@@ -4,7 +4,7 @@ global.requireLocal = require('local-modules').GetModule;
 
 (function() {
 	// --Setup Blynk in another file and pass it in to start the rest of the program
-	requireLocal('blynk-setup').Setup((_blynk) => {
+	requireLocal('blynk-setup')((_blynk) => {
 		var _gpio = require('onoff').Gpio;
 		var _schedule = require('node-schedule');
 		var _dbo = requireLocal('database-operations');

--- a/bin/program.js
+++ b/bin/program.js
@@ -43,7 +43,7 @@ global.requireLocal = require('local-modules').GetModule;
 		var _wellValveRelayOutput = new _gpio(17, 'high');
 		var _boilerStartRelayOutput = new _gpio(27, 'high');
 		
-		var _mapping = require('./mapping').GetMapping();
+		var _mapping = requireLocal('mapping')();
 		var _data;
 		var _isWellCharged;
 		var _isCallForHeat = false;

--- a/node_modules/local-modules.js
+++ b/node_modules/local-modules.js
@@ -1,8 +1,8 @@
 
-// --Set this at the top of the main program
 // global.requireLocal = require('name-of-this-file').GetModule;
 // --Call with requireLocal('file-to-get') to automatically get the right file
 
+var _fs = require('fs');
 var _paths;
 
 var _outerFunc = module.exports = {
@@ -17,7 +17,6 @@ var _outerFunc = module.exports = {
 		return require(path);
 
 		function GetAllFilePaths() {
-			var _fs = require('fs');
 
 			var _rootDir = '../bin';
 			_paths = ScanDirectory(__dirname + '/' + _rootDir);

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,16 +46,6 @@
         "ndjson": "1.5.0"
       }
     },
-    "debug": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-      "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
-    },
-    "deep-is": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz",
-      "integrity": "sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg="
-    },
     "define-properties": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
@@ -104,14 +94,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-    },
-    "is2": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-0.0.9.tgz",
-      "integrity": "sha1-EZVW0dFlGkG6EFr4AyZ8gLKZ9ik=",
-      "requires": {
-        "deep-is": "0.1.2"
-      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -3139,11 +3121,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
-    "q": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
-      "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
-    },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
@@ -3187,16 +3164,6 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
         "safe-buffer": "5.1.1"
-      }
-    },
-    "tcp-port-used": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-0.1.2.tgz",
-      "integrity": "sha1-lFDodoyDtBb9TRpqlEnuzL9JbCk=",
-      "requires": {
-        "debug": "0.7.4",
-        "is2": "0.0.9",
-        "q": "0.9.7"
       }
     },
     "through2": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "csv-write-stream": "^2.0.0",
     "node-schedule": "^1.2.5",
     "npm": "^5.4.2",
-    "onoff": "^1.1.7",
-    "tcp-port-used": "^0.1.2"
+    "onoff": "^1.1.7"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
The local server has been moved to inside the project and will be automatically started before the rest of the program starts. This gets rid of having to scan for the server port to be occupied before Blynk connects and simplifies alleviates the hassle of having to configure the server and run it separately.

Also:
- removed GetMapping() from mapping because it is the only function which can be invoked on import
- removed GetAuth() from `install.sh` for the same reason
- restructured `blynk-setup.js`