### PR TITLE
Schedule Fixes

### DIFF
--- a/bin/program.js
+++ b/bin/program.js
@@ -296,6 +296,13 @@ global.requireLocal = require('local-modules').GetModule;
 					else {
 						var arr = newSchedule.split(' ');
 						arr[0] = parseInt(arr[0]) + 1;
+
+						// --59 is the max value for a minute, increase the hour by 1 if need be
+						if (arr[0] == 60) {
+							arr[0] = 0;
+							arr[1] = parseInt(arr[1]) + 1;
+						}
+
 						newSchedule = arr.join(' ');
 						job.reschedule(newSchedule);
 					}

--- a/bin/program.js
+++ b/bin/program.js
@@ -297,7 +297,7 @@ global.requireLocal = require('local-modules').GetModule;
 						var arr = newSchedule.split(' ');
 						arr[0] = parseInt(arr[0]) + 1;
 
-						// --59 is the max value for a minute, increase the hour by 1 if need be
+						// Increase the hour by 1 if need be
 						if (arr[0] == 60) {
 							arr[0] = 0;
 							arr[1] = parseInt(arr[1]) + 1;

--- a/bin/program.js
+++ b/bin/program.js
@@ -303,7 +303,9 @@ global.requireLocal = require('local-modules').GetModule;
 							arr[1] = parseInt(arr[1]) + 1;
 						}
 
-						newSchedule = arr.join(' ');
+						// --Reset to the original schedule if 24 hours have passed
+						arr[1] == 24 ? newSchedule = originalSchedule : newSchedule = arr.join(' ');
+
 						job.reschedule(newSchedule);
 					}
 				});


### PR DESCRIPTION
The program was set to add a minute to each schedule if a schedule was supposed to run when the system could be reading/writing to a file. Sometimes the schedule would be delayed more than 59 minutes, which is the maximum number for minutes for a chron scheduled job. Any more time added on would make the chron job invalid, and the schedule would never run. Simple hour parsing was added to add an hour to the cron job if it were delayed more than an hour.